### PR TITLE
feat(architecture): layered restructure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,20 @@ cosmos = [
     "wandb>=0.15",
     "lerobot>=0.5",
 ]
+diffusion = [
+    "diffusers>=0.35",
+    "transformers>=4.49",
+    "torchvision>=0.15",
+    "accelerate>=0.25",
+    "sentencepiece>=0.2",
+    "ftfy>=6.0",
+    "Pillow>=9.0",
+]
+quant = [
+    "torchao>=0.5",
+]
 all = [
-    "worldkernels[cosmos]",
+    "worldkernels[cosmos,diffusion,quant]",
 ]
 dev = [
     "pytest>=7.0",
@@ -113,9 +125,9 @@ docs = [
 worldkernels = "worldkernels.cli.main:app"
 
 [project.entry-points."worldkernels.worlds"]
-dummy = "worldkernels.worlds.adapters.dummy:DummyWorld"
-dreamdojo = "worldkernels.worlds.adapters.dreamdojo:DreamDojoWorld"
-cosmos_predict2 = "worldkernels.worlds.adapters.cosmos:CosmosPredict2World"
+dummy = "worldkernels.worlds.dummy:DummyWorld"
+dreamdojo = "worldkernels.worlds.dreamdojo:DreamDojoWorld"
+generator_world = "worldkernels.worlds.base:GeneratorWorld"
 
 [project.urls]
 Homepage = "https://github.com/soran-ghaderi/worldkernels"

--- a/tests/_helpers/mocks.py
+++ b/tests/_helpers/mocks.py
@@ -12,11 +12,11 @@ from worldkernels.core.config import WorldConfig
 from worldkernels.core.observation import Observation
 from worldkernels.core.session import LatentState
 from worldkernels.runtime.stages import StageExecMode, StageType, TransitionMode
-from worldkernels.worlds.base import AbstractWorld
+from worldkernels.worlds.base import WorldModel
 
 
-class MockWorld(AbstractWorld):
-    r"""Minimal CPU AbstractWorld for runtime/engine/session tests.
+class MockWorld(WorldModel):
+    r"""Minimal CPU WorldModel for runtime/engine/session tests.
 
     Records every method invocation so tests can verify the executor
     actually drove the stages in the right order.
@@ -72,7 +72,7 @@ class MockWorld(AbstractWorld):
             audio=b"\x00" if "audio" in modalities else None,
         )
 
-    def estimate_vram_mb(self, config: WorldConfig) -> float:
+    def profile_vram(self, config: WorldConfig) -> float:
         return float(config.height * config.width) / 1024.0
 
     def create_initial_state(self, config: WorldConfig, seed: int) -> LatentState:
@@ -106,7 +106,7 @@ class SlowMockWorld(MockWorld):
         return super().decode_observation(state, modalities)
 
 
-def register_mock_world(name: str = "mock", cls: type[AbstractWorld] = MockWorld) -> None:
+def register_mock_world(name: str = "mock", cls: type[WorldModel] = MockWorld) -> None:
     r"""Register a mock world into the global worlds registry for tests that
     need the full hub/registry resolution path."""
     from worldkernels.worlds import registry

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -22,7 +22,7 @@ class TestRunServe:
         called = {}
         monkeypatch.setattr("uvicorn.run", lambda *a, **kw: called.setdefault("uvicorn", True))
 
-        with patch("worldkernels.core.engine.WorldKernel.load_model") as load_mock:
+        with patch("worldkernels.engine.WorldEngine.load_model") as load_mock:
             run_serve("0.0.0.0", 8000, 2, None, "cpu", "dummy", {})
             load_mock.assert_called_once_with("dummy")
 
@@ -32,6 +32,6 @@ class TestRunServe:
 
     def test_with_model_kwargs(self, monkeypatch):
         monkeypatch.setattr("uvicorn.run", lambda *a, **kw: None)
-        with patch("worldkernels.core.engine.WorldKernel.load_model") as load_mock:
+        with patch("worldkernels.engine.WorldEngine.load_model") as load_mock:
             run_serve("0.0.0.0", 8000, 1, "k", "cpu", "dummy", {"variant": "v"})
             load_mock.assert_called_once_with("dummy", variant="v")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,7 +11,7 @@ os.environ["WORLDKERNELS_NO_AUTO_INSTALL"] = "1"
 
 from tests._helpers.factories import make_world_config  # noqa: E402
 from tests._helpers.mocks import MockWorld  # noqa: E402
-from worldkernels.core.engine import WorldKernel  # noqa: E402
+from worldkernels.engine import WorldEngine  # noqa: E402
 from worldkernels.worlds import (
     hub as _hub,  # noqa: E402
     registry as _registry,  # noqa: E402
@@ -44,7 +44,7 @@ def world_config():
 
 @pytest.fixture
 def engine():
-    wk = WorldKernel(device="cpu", max_sessions=4)
+    wk = WorldEngine(device="cpu", max_sessions=4)
     wk.load_model("dummy")
     yield wk
     wk.shutdown()

--- a/tests/core/test___init__.py
+++ b/tests/core/test___init__.py
@@ -13,14 +13,12 @@ def test_all_exports_resolvable():
 def test_exports_correct_classes():
     from worldkernels.core.action import Action
     from worldkernels.core.config import ServerConfig, WorldConfig
-    from worldkernels.core.engine import WorldKernel
     from worldkernels.core.observation import Observation
     from worldkernels.core.session import LatentState, Session, SessionStatus
 
     assert core.Action is Action
     assert core.WorldConfig is WorldConfig
     assert core.ServerConfig is ServerConfig
-    assert core.WorldKernel is WorldKernel
     assert core.Observation is Observation
     assert core.Session is Session
     assert core.LatentState is LatentState

--- a/tests/core/test_engine.py
+++ b/tests/core/test_engine.py
@@ -1,4 +1,4 @@
-r"""Tests for worldkernels/core/engine.py."""
+r"""Tests for worldkernels/engine/world_engine.py."""
 
 from __future__ import annotations
 
@@ -9,7 +9,6 @@ import torch
 
 from tests._helpers.factories import make_world_config
 from tests._helpers.mocks import MockWorld, register_mock_world, unregister_world
-from worldkernels.core.engine import WorldKernel, _default_dtype
 from worldkernels.core.errors import (
     SessionLimitError,
     VRAMExhaustedError,
@@ -17,6 +16,8 @@ from worldkernels.core.errors import (
     WorldInitError,
     WorldNotFoundError,
 )
+from worldkernels.engine import WorldEngine
+from worldkernels.engine.world_engine import _default_dtype
 
 
 class TestDefaultDtype:
@@ -44,20 +45,20 @@ class TestDefaultDtype:
 
 class TestWorldKernelInit:
     def test_defaults(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             assert wk.device == "cpu"
             assert wk.max_sessions == 4
             assert wk.offload_idle is True
             assert wk.dtype == torch.float32
-            assert wk._executor is not None
+            assert wk._scheduler is not None
             assert wk.list_worlds() == []
             assert wk.list_sessions() == []
         finally:
             wk.shutdown()
 
     def test_overrides(self):
-        wk = WorldKernel(device="cpu", max_sessions=8, offload_idle=False)
+        wk = WorldEngine(device="cpu", max_sessions=8, offload_idle=False)
         try:
             assert wk.max_sessions == 8
             assert wk.offload_idle is False
@@ -67,7 +68,7 @@ class TestWorldKernelInit:
 
 class TestLoadModel:
     def test_load_dummy(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             assert "dummy" in wk.list_worlds()
@@ -75,7 +76,7 @@ class TestLoadModel:
             wk.shutdown()
 
     def test_load_unknown_raises(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             with pytest.raises(WorldNotFoundError):
                 wk.load_model("nonexistent_xyz")
@@ -83,7 +84,7 @@ class TestLoadModel:
             wk.shutdown()
 
     def test_load_with_alias(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy", alias="d1")
             assert "d1" in wk.list_worlds()
@@ -92,7 +93,7 @@ class TestLoadModel:
             wk.shutdown()
 
     def test_already_loaded_raises(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             with pytest.raises(WorldAlreadyLoadedError):
@@ -101,7 +102,7 @@ class TestLoadModel:
             wk.shutdown()
 
     def test_hf_repo_id_resolved_via_hub(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             register_mock_world("dreamdojo")
             try:
@@ -118,7 +119,7 @@ class TestLoadModel:
                 raise RuntimeError("boom")
 
         register_mock_world("_bad", BadWorld)
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             with pytest.raises(WorldInitError, match="boom"):
                 wk.load_model("_bad")
@@ -129,19 +130,19 @@ class TestLoadModel:
 
 class TestCreateSession:
     def test_creates_active(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             s = wk.create_session("dummy", config=make_world_config())
             assert s.world_id == "dummy"
             assert s.session_id in wk._sessions
             assert s._world is wk._worlds["dummy"]
-            assert s._executor is wk._executor
+            assert s._scheduler is wk._scheduler
         finally:
             wk.shutdown()
 
     def test_default_config(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             s = wk.create_session("dummy")
@@ -151,7 +152,7 @@ class TestCreateSession:
             wk.shutdown()
 
     def test_unknown_world_raises(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             with pytest.raises(WorldNotFoundError):
                 wk.create_session("nope")
@@ -159,7 +160,7 @@ class TestCreateSession:
             wk.shutdown()
 
     def test_session_limit(self):
-        wk = WorldKernel(device="cpu", max_sessions=2)
+        wk = WorldEngine(device="cpu", max_sessions=2)
         try:
             wk.load_model("dummy")
             cfg = make_world_config()
@@ -171,7 +172,7 @@ class TestCreateSession:
             wk.shutdown()
 
     def test_default_seed_is_zero(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             s = wk.create_session("dummy")
@@ -180,7 +181,7 @@ class TestCreateSession:
             wk.shutdown()
 
     def test_vram_check_raises(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             hungry = _HungryWorld()
             hungry.initialize("cpu", torch.float32)
@@ -196,7 +197,7 @@ class TestCreateSession:
             wk.shutdown()
 
     def test_vram_check_passes_when_enough_free(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             wk.device = "cuda:0"
@@ -213,20 +214,20 @@ class TestCreateSession:
 class _HungryWorld(MockWorld):
     name = "hungry"
 
-    def estimate_vram_mb(self, config):
+    def profile_vram(self, config):
         return 1e9
 
 
 class TestSessionManagement:
     def test_get_session_returns_none_for_unknown(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             assert wk.get_session("missing") is None
         finally:
             wk.shutdown()
 
     def test_get_session_returns_session(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             s = wk.create_session("dummy")
@@ -235,7 +236,7 @@ class TestSessionManagement:
             wk.shutdown()
 
     def test_close_session_terminates(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             s = wk.create_session("dummy")
@@ -248,14 +249,14 @@ class TestSessionManagement:
             wk.shutdown()
 
     def test_close_session_unknown_is_noop(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.close_session("missing")
         finally:
             wk.shutdown()
 
     def test_list_sessions(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             s1 = wk.create_session("dummy")
@@ -268,7 +269,7 @@ class TestSessionManagement:
 
 class TestUnloadModel:
     def test_unloads_and_closes_sessions(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             wk.load_model("dummy")
             s = wk.create_session("dummy")
@@ -279,7 +280,7 @@ class TestUnloadModel:
             wk.shutdown()
 
     def test_unload_unknown_raises(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         try:
             with pytest.raises(WorldNotFoundError):
                 wk.unload_model("ghost")
@@ -289,7 +290,7 @@ class TestUnloadModel:
 
 class TestShutdown:
     def test_shutdown_clears_state(self):
-        wk = WorldKernel(device="cpu")
+        wk = WorldEngine(device="cpu")
         wk.load_model("dummy")
         wk.create_session("dummy")
         wk.shutdown()

--- a/tests/core/test_session.py
+++ b/tests/core/test_session.py
@@ -114,7 +114,7 @@ class TestSessionDefaults:
 
 class TestSessionStepGuards:
     def _make(self, status: SessionStatus) -> Session:
-        s = Session(_world=MockWorld(), _executor=MagicMock())
+        s = Session(_world=MockWorld(), _scheduler=MagicMock())
         s.status = status
         return s
 
@@ -128,7 +128,7 @@ class TestSessionStepGuards:
         with pytest.raises(SessionPausedError):
             s.step(Action("null"))
 
-    def test_step_without_executor_or_world_raises(self):
+    def test_step_without_scheduler_or_world_raises(self):
         s = Session()
         with pytest.raises(RuntimeError, match="not bound"):
             s.step(Action("null"))

--- a/tests/distributed/test_parallel_state.py
+++ b/tests/distributed/test_parallel_state.py
@@ -1,0 +1,86 @@
+r"""Single-rank identity tests for the distributed substrate.
+
+Multi-rank correctness (process groups, collectives) is exercised by a
+torchrun launch; here we verify that the all-ones config is a pure no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from worldkernels.config import ParallelConfig
+from worldkernels.distributed import (
+    CFGParallelMixin,
+    get_cfg_parallel_world_size,
+    get_sequence_parallel_world_size,
+    get_tensor_parallel_group,
+    get_tensor_parallel_rank,
+    get_tensor_parallel_world_size,
+    init_distributed,
+    is_initialized,
+    ring_rotate,
+    tensor_parallel_all_gather,
+    tensor_parallel_all_reduce,
+    ulysses_all_to_all,
+)
+
+
+@pytest.fixture(autouse=True)
+def _single_rank():
+    init_distributed(ParallelConfig())
+    yield
+
+
+class TestParallelState:
+    def test_single_rank_initialized(self):
+        assert is_initialized()
+        assert get_tensor_parallel_rank() == 0
+        assert get_tensor_parallel_world_size() == 1
+        assert get_sequence_parallel_world_size() == 1
+        assert get_cfg_parallel_world_size() == 1
+        assert get_tensor_parallel_group() is None
+
+    def test_multi_rank_world_size_product(self):
+        cfg = ParallelConfig(tensor_parallel_size=2, ulysses_degree=2, cfg_parallel_size=2)
+        assert cfg.world_size == 8
+        assert cfg.sequence_parallel_size == 2
+
+    def test_cfg_parallel_size_validated(self):
+        with pytest.raises(ValueError, match="cfg_parallel_size"):
+            ParallelConfig(cfg_parallel_size=3)
+
+
+class TestCollectivesSingleRank:
+    def test_all_reduce_is_identity(self):
+        t = torch.tensor([1.0, 2.0, 3.0])
+        assert tensor_parallel_all_reduce(t) is t
+
+    def test_all_gather_is_identity(self):
+        t = torch.tensor([1.0, 2.0])
+        assert tensor_parallel_all_gather(t) is t
+
+    def test_ulysses_all_to_all_is_identity(self):
+        x = torch.rand(2, 4, 8)
+        assert ulysses_all_to_all(x, scatter_dim=1, gather_dim=2) is x
+
+    def test_ring_rotate_is_identity(self):
+        t = torch.rand(3, 5)
+        assert ring_rotate(t) is t
+
+
+class TestCFGParallelSingleRank:
+    def test_not_enabled(self):
+        assert CFGParallelMixin.cfg_parallel_enabled() is False
+
+    def test_forward_combines_cond_and_uncond(self):
+        def model(*, value):
+            return torch.full((2,), float(value))
+
+        out = CFGParallelMixin.cfg_parallel_forward(
+            model,
+            cond_kwargs={"value": 3.0},
+            uncond_kwargs={"value": 1.0},
+            guidance_scale=2.0,
+        )
+        assert torch.allclose(out, torch.full((2,), 1.0 + 2.0 * (3.0 - 1.0)))

--- a/tests/engine/test_async_engine.py
+++ b/tests/engine/test_async_engine.py
@@ -1,0 +1,74 @@
+r"""Tests for the AsyncEngine continuous-batching front-end (CPU-safe)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from worldkernels.config import WorldConfig
+from worldkernels.core.action import Action
+from worldkernels.core.errors import SessionNotFoundError
+from worldkernels.engine import AsyncEngine, WorldEngine
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _config() -> WorldConfig:
+    return WorldConfig(height=32, width=32, frames_per_step=1)
+
+
+class TestAsyncEngine:
+    def test_step_returns_observation(self):
+        async def main():
+            engine = AsyncEngine(WorldEngine(device="cpu", max_sessions=4))
+            await engine.load_model("dummy")
+            session = await engine.create_session("dummy", config=_config())
+            obs = await engine.step(session.session_id, Action("null", {}))
+            await engine.shutdown()
+            return obs
+
+        obs = _run(main())
+        assert obs.frames is not None
+        assert obs.stage_timing is not None
+
+    def test_step_advances_session_index(self):
+        async def main():
+            engine = AsyncEngine(WorldEngine(device="cpu", max_sessions=4))
+            await engine.load_model("dummy")
+            session = await engine.create_session("dummy", config=_config())
+            await engine.step(session.session_id, Action("null", {}))
+            await engine.step(session.session_id, Action("null", {}))
+            idx = session.step_index
+            await engine.shutdown()
+            return idx
+
+        assert _run(main()) == 2
+
+    def test_concurrent_steps_batch_together(self):
+        async def main():
+            engine = AsyncEngine(WorldEngine(device="cpu", max_sessions=8))
+            await engine.load_model("dummy")
+            sessions = [await engine.create_session("dummy", config=_config()) for _ in range(4)]
+            results = await asyncio.gather(
+                *(engine.step(s.session_id, Action("null", {})) for s in sessions)
+            )
+            await engine.shutdown()
+            return results
+
+        results = _run(main())
+        assert len(results) == 4
+        assert all(obs.frames is not None for obs in results)
+
+    def test_step_unknown_session_raises(self):
+        async def main():
+            engine = AsyncEngine(WorldEngine(device="cpu"))
+            try:
+                with pytest.raises(SessionNotFoundError):
+                    await engine.step("ghost", Action("null", {}))
+            finally:
+                await engine.shutdown()
+
+        _run(main())

--- a/tests/runtime/test_attention.py
+++ b/tests/runtime/test_attention.py
@@ -1,0 +1,54 @@
+r"""Tests for the pluggable attention backends (CPU-safe)."""
+
+from __future__ import annotations
+
+import torch
+
+from worldkernels.runtime.attention import (
+    AttentionMetadata,
+    SDPABackend,
+    select_attention_backend,
+)
+
+
+def _qkv(batch=2, seq=4, heads=3, dim=8):
+    g = torch.Generator().manual_seed(0)
+    shape = (batch, seq, heads, dim)
+    return (
+        torch.rand(shape, generator=g),
+        torch.rand(shape, generator=g),
+        torch.rand(shape, generator=g),
+    )
+
+
+class TestSDPABackend:
+    def test_output_shape_preserved(self):
+        q, k, v = _qkv()
+        out = SDPABackend().forward(q, k, v)
+        assert out.shape == q.shape
+
+    def test_causal_matches_reference(self):
+        q, k, v = _qkv(batch=1, heads=1)
+        out = SDPABackend().forward(q, k, v, is_causal=True)
+        ref = torch.nn.functional.scaled_dot_product_attention(
+            q.transpose(1, 2), k.transpose(1, 2), v.transpose(1, 2), is_causal=True
+        ).transpose(1, 2)
+        assert torch.allclose(out, ref, atol=1e-6)
+
+
+class TestSelector:
+    def test_sdpa_explicit(self):
+        assert isinstance(select_attention_backend("sdpa"), SDPABackend)
+
+    def test_flash_falls_back_to_sdpa_when_unavailable(self):
+        backend = select_attention_backend("flash")
+        assert backend.name in ("flash", "sdpa")
+
+    def test_default_resolves(self):
+        assert select_attention_backend() is not None
+
+
+def test_attention_metadata_defaults():
+    meta = AttentionMetadata()
+    assert meta.is_causal is False
+    assert meta.scale is None

--- a/tests/runtime/test_cache.py
+++ b/tests/runtime/test_cache.py
@@ -1,0 +1,48 @@
+r"""Tests for the TeaCache denoise-step cache."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from worldkernels.runtime.cache import TeaCache
+
+
+class TestTeaCache:
+    def test_first_step_always_computes(self):
+        cache = TeaCache()
+        assert cache.should_compute(torch.zeros(4)) is True
+
+    def test_skips_when_change_below_threshold(self):
+        cache = TeaCache(rel_l1_threshold=0.5)
+        base = torch.ones(4)
+        cache.should_compute(base)
+        cache.store(torch.ones(4))
+        assert cache.should_compute(base * 1.01) is False
+        assert cache.hits == 1
+
+    def test_recomputes_when_change_exceeds_threshold(self):
+        cache = TeaCache(rel_l1_threshold=0.05)
+        cache.should_compute(torch.ones(4))
+        cache.store(torch.ones(4))
+        assert cache.should_compute(torch.ones(4) * 5.0) is True
+
+    def test_hit_rate(self):
+        cache = TeaCache(rel_l1_threshold=10.0)
+        cache.should_compute(torch.ones(4))
+        cache.store(torch.ones(4))
+        for _ in range(3):
+            cache.should_compute(torch.ones(4))
+        assert cache.hit_rate == pytest.approx(0.75)
+
+    def test_reset_clears_state(self):
+        cache = TeaCache()
+        cache.should_compute(torch.ones(4))
+        cache.store(torch.ones(4))
+        cache.reset()
+        assert cache.cached_residual is None
+        assert cache.hits == 0
+
+    def test_negative_threshold_rejected(self):
+        with pytest.raises(ValueError, match="rel_l1_threshold"):
+            TeaCache(rel_l1_threshold=-1.0)

--- a/tests/runtime/test_compile.py
+++ b/tests/runtime/test_compile.py
@@ -1,0 +1,58 @@
+r"""Tests for the compile backends (CPU-safe paths)."""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import torch.nn as nn
+
+from worldkernels.runtime.compile import CUDAGraphRunner, regionally_compile
+
+
+class _Block(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.lin = nn.Linear(4, 4)
+
+    def forward(self, x):
+        return self.lin(x)
+
+
+class _Model(nn.Module):
+    _repeated_blocks = ["blocks"]
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.blocks = nn.ModuleList([_Block() for _ in range(3)])
+
+    def forward(self, x):
+        for block in self.blocks:
+            x = block(x)
+        return x
+
+
+class TestRegionallyCompile:
+    def test_returns_module_and_preserves_output(self):
+        model = _Model()
+        x = torch.rand(2, 4)
+        expected = model(x)
+        compiled = regionally_compile(model)
+        assert compiled is model
+        assert torch.allclose(compiled(x), expected, atol=1e-5)
+
+    def test_compiles_each_repeated_block(self):
+        model = regionally_compile(_Model())
+        assert len(model.blocks) == 3
+
+
+class TestCUDAGraphRunner:
+    def test_requires_cuda(self):
+        runner = CUDAGraphRunner()
+        assert runner.is_captured is False
+        if not torch.cuda.is_available():
+            with pytest.raises(RuntimeError, match="CUDA"):
+                runner.capture(lambda t: t, torch.zeros(2))
+
+    def test_replay_before_capture_raises(self):
+        with pytest.raises(RuntimeError, match="not captured"):
+            CUDAGraphRunner().replay(torch.zeros(2))

--- a/tests/runtime/test_memory.py
+++ b/tests/runtime/test_memory.py
@@ -1,11 +1,149 @@
-r"""Tests for worldkernels/runtime/memory.py (currently a stub)."""
+r"""Tests for the worldkernels/runtime/memory subsystem (CPU-safe)."""
 
 from __future__ import annotations
 
-from worldkernels.runtime.memory import LatentCacheManager
+import pytest
+import torch
+
+from worldkernels.runtime.memory import (
+    BlockManager,
+    KVCacheManager,
+    LatentPool,
+    MemoryTier,
+    Offloader,
+    TrajectoryCache,
+)
 
 
-class TestLatentCacheManager:
-    def test_importable_and_instantiable(self):
-        mgr = LatentCacheManager()
-        assert isinstance(mgr, LatentCacheManager)
+def _block_manager(num_blocks: int = 4) -> BlockManager:
+    return BlockManager(
+        block_shape=(4, 8), num_blocks=num_blocks, device="cpu", dtype=torch.float32
+    )
+
+
+class TestBlockManager:
+    def test_allocate_and_free(self):
+        bm = _block_manager(4)
+        ids = bm.allocate(3)
+        assert len(ids) == 3
+        assert bm.num_allocated == 3
+        assert bm.num_free == 1
+        bm.free(ids)
+        assert bm.num_free == 4
+
+    def test_block_view_shape(self):
+        bm = _block_manager()
+        (block_id,) = bm.allocate(1)
+        assert bm.block(block_id).shape == (4, 8)
+
+    def test_exhaustion_raises(self):
+        bm = _block_manager(2)
+        bm.allocate(2)
+        with pytest.raises(MemoryError, match="exhausted"):
+            bm.allocate(1)
+
+    def test_copy_on_write_share(self):
+        bm = _block_manager()
+        ids = bm.allocate(1)
+        bm.share(ids)
+        assert bm.refcount(ids[0]) == 2
+        bm.free(ids)
+        assert bm.num_allocated == 1
+        bm.free(ids)
+        assert bm.num_allocated == 0
+
+    def test_reset(self):
+        bm = _block_manager()
+        bm.allocate(3)
+        bm.reset()
+        assert bm.num_free == 4
+
+
+class TestLatentPool:
+    def test_acquire_returns_requested_shape(self):
+        pool = LatentPool(device="cpu")
+        buf = pool.acquire((2, 3), torch.float32)
+        assert buf.shape == (2, 3)
+        assert pool.num_in_use == 1
+
+    def test_release_recycles_buffer(self):
+        pool = LatentPool(device="cpu")
+        buf = pool.acquire((2, 3), torch.float32)
+        pool.release(buf)
+        assert pool.num_pooled == 1
+        assert pool.acquire((2, 3), torch.float32) is buf
+
+    def test_distinct_shapes_not_mixed(self):
+        pool = LatentPool(device="cpu")
+        pool.release(pool.acquire((2, 3), torch.float32))
+        other = pool.acquire((4, 4), torch.float32)
+        assert other.shape == (4, 4)
+
+
+class TestOffloader:
+    def test_tier_of_cpu_tensor(self):
+        assert Offloader.tier_of(torch.zeros(2)) is MemoryTier.HOST
+
+    def test_offload_to_host_is_noop_on_cpu(self):
+        off = Offloader(device="cpu")
+        t = torch.zeros(2)
+        assert off.offload(t, MemoryTier.HOST) is t
+
+    def test_nvme_tier_not_implemented(self):
+        off = Offloader(device="cpu")
+        with pytest.raises(NotImplementedError):
+            off.offload(torch.zeros(2), MemoryTier.NVME)
+
+
+class TestKVCacheManager:
+    def test_allocate_and_block_table(self):
+        kv = KVCacheManager(_block_manager(8))
+        kv.allocate("s1", 3)
+        assert len(kv.block_table("s1")) == 3
+
+    def test_append_grows_table(self):
+        kv = KVCacheManager(_block_manager(8))
+        kv.allocate("s1", 2)
+        kv.append("s1", 2)
+        assert len(kv.block_table("s1")) == 4
+
+    def test_fork_shares_blocks_copy_on_write(self):
+        bm = _block_manager(8)
+        kv = KVCacheManager(bm)
+        kv.allocate("s1", 3)
+        kv.fork("s1", "s2")
+        assert kv.block_table("s2") == kv.block_table("s1")
+        assert bm.refcount(kv.block_table("s1")[0]) == 2
+        kv.free("s1")
+        assert bm.num_allocated == 3
+
+    def test_free_releases_blocks(self):
+        bm = _block_manager(8)
+        kv = KVCacheManager(bm)
+        kv.allocate("s1", 3)
+        kv.free("s1")
+        assert bm.num_allocated == 0
+
+
+class TestTrajectoryCache:
+    def test_match_full_prefix(self):
+        cache = TrajectoryCache()
+        cache.insert(["a", "b", "c"], [10, 11, 12])
+        match = cache.match(["a", "b", "c"])
+        assert match.length == 3
+        assert match.block_ids == [10, 11, 12]
+
+    def test_match_partial_prefix(self):
+        cache = TrajectoryCache()
+        cache.insert(["a", "b"], [10, 11])
+        assert cache.match(["a", "b", "x"]).length == 2
+
+    def test_match_no_prefix(self):
+        cache = TrajectoryCache()
+        cache.insert(["a"], [10])
+        assert cache.match(["z"]).length == 0
+
+    def test_insert_length_mismatch_raises(self):
+        cache = TrajectoryCache()
+        with pytest.raises(ValueError, match="equal length"):
+            cache.insert(["a", "b"], [1])

--- a/tests/runtime/test_metrics.py
+++ b/tests/runtime/test_metrics.py
@@ -1,10 +1,33 @@
-r"""Tests for worldkernels/runtime/metrics.py (currently a stub)."""
+r"""Tests for the Prometheus metrics module."""
 
 from __future__ import annotations
 
+from worldkernels.runtime import metrics
 
-def test_module_importable():
-    import worldkernels.runtime.metrics as metrics
 
-    assert metrics.__doc__ is not None
-    assert "Prometheus" in metrics.__doc__
+def test_render_emits_prometheus_text():
+    out = metrics.render()
+    assert isinstance(out, bytes)
+    assert b"wk_step_latency_seconds" in out
+
+
+def test_observe_step_increments_counters():
+    before = metrics.render()
+    metrics.observe_step(0.05, frames=4)
+    after = metrics.render()
+    assert b"wk_steps_total" in after
+    assert before != after
+
+
+def test_observe_batch_records_size():
+    metrics.observe_batch(4)
+    assert b"wk_batch_size" in metrics.render()
+
+
+def test_gauges_settable():
+    metrics.set_active_sessions(3)
+    metrics.set_vram_bytes(1024.0)
+    metrics.set_cache_hit_ratio(0.5)
+    out = metrics.render()
+    assert b"wk_active_sessions 3.0" in out
+    assert b"wk_cache_hit_ratio 0.5" in out

--- a/tests/runtime/test_quantization.py
+++ b/tests/runtime/test_quantization.py
@@ -1,10 +1,35 @@
-r"""Tests for worldkernels/runtime/quantization.py (currently a stub)."""
+r"""Tests for the quantization registry."""
 
 from __future__ import annotations
 
+import pytest
+import torch.nn as nn
 
-def test_module_importable():
-    import worldkernels.runtime.quantization as q
+from worldkernels.runtime.quantization import QuantizationRegistry, QuantizationScheme
 
-    assert q.__doc__ is not None
-    assert "Quantization" in q.__doc__
+
+class TestQuantizationRegistry:
+    def test_none_scheme_is_identity(self):
+        module = nn.Linear(4, 4)
+        assert QuantizationRegistry().apply(module, QuantizationScheme.NONE) is module
+
+    def test_accepts_string_scheme(self):
+        module = nn.Linear(4, 4)
+        assert QuantizationRegistry().apply(module, "none") is module
+
+    def test_unknown_scheme_rejected(self):
+        with pytest.raises(ValueError):
+            QuantizationRegistry().apply(nn.Linear(4, 4), "bogus")
+
+    def test_int8_without_torchao_raises_actionable_error(self):
+        try:
+            import torchao  # noqa: F401
+        except ImportError:
+            with pytest.raises(ImportError, match="worldkernels"):
+                QuantizationRegistry().apply(nn.Linear(4, 4), QuantizationScheme.INT8)
+
+    def test_register_custom_applier(self):
+        registry = QuantizationRegistry()
+        marker = nn.Linear(2, 2)
+        registry.register(QuantizationScheme.INT4, lambda _m: marker)
+        assert registry.apply(nn.Linear(4, 4), QuantizationScheme.INT4) is marker

--- a/tests/runtime/test_scheduler.py
+++ b/tests/runtime/test_scheduler.py
@@ -1,9 +1,0 @@
-r"""Tests for worldkernels/runtime/scheduler.py (currently a stub)."""
-
-from __future__ import annotations
-
-
-def test_module_importable():
-    import worldkernels.runtime.scheduler as scheduler
-
-    assert scheduler is not None

--- a/tests/scheduler/test_scheduler.py
+++ b/tests/scheduler/test_scheduler.py
@@ -1,0 +1,141 @@
+r"""Tests for the scheduler: batching, admission, preemption, dispatch."""
+
+from __future__ import annotations
+
+import pytest
+
+from worldkernels.config import SchedulerConfig, WorldConfig
+from worldkernels.core.request import StepRequest
+from worldkernels.runtime.stages import TransitionMode
+from worldkernels.scheduler import (
+    AdmissionController,
+    PreemptionCandidate,
+    PreemptionPolicy,
+    Scheduler,
+    group_requests,
+)
+
+
+class _FakeWorld:
+    transition_mode = TransitionMode.BIDIRECTIONAL
+
+    def __init__(self, vram_mb: float = 100.0) -> None:
+        self._vram = vram_mb
+
+    def profile_vram(self, config: WorldConfig) -> float:
+        return self._vram
+
+
+class _FakeWorker:
+    def __init__(self) -> None:
+        self.batches: list[int] = []
+
+    def execute(self, requests):
+        self.batches.append(len(requests))
+        return [(r.state, f"obs-{r.session_id}") for r in requests]
+
+
+def _request(session_id: str, world: _FakeWorld) -> StepRequest:
+    return StepRequest(session_id=session_id, world=world, state=None, action=None)
+
+
+class TestBatching:
+    def test_same_world_groups_together(self):
+        world = _FakeWorld()
+        reqs = [_request(f"s{i}", world) for i in range(3)]
+        groups = group_requests(reqs, max_batch_size=8)
+        assert len(groups) == 1
+        assert groups[0].size == 3
+
+    def test_distinct_worlds_separate_groups(self):
+        reqs = [_request("a", _FakeWorld()), _request("b", _FakeWorld())]
+        groups = group_requests(reqs, max_batch_size=8)
+        assert len(groups) == 2
+
+    def test_max_batch_size_splits_group(self):
+        world = _FakeWorld()
+        reqs = [_request(f"s{i}", world) for i in range(5)]
+        groups = group_requests(reqs, max_batch_size=2)
+        assert sorted(g.size for g in groups) == [1, 2, 2]
+
+
+class TestAdmission:
+    def _controller(self, **kw) -> AdmissionController:
+        return AdmissionController(SchedulerConfig(**kw))
+
+    def test_admits_when_vram_fits(self):
+        decision = self._controller().check(
+            _FakeWorld(vram_mb=500), WorldConfig(), live_sessions=0, free_vram_mb=4000
+        )
+        assert decision.admitted
+
+    def test_refuses_when_vram_short(self):
+        decision = self._controller(admission_headroom_mb=512).check(
+            _FakeWorld(vram_mb=4000), WorldConfig(), live_sessions=0, free_vram_mb=4200
+        )
+        assert not decision.admitted
+        assert "VRAM" in decision.reason
+
+    def test_refuses_at_concurrency_cap(self):
+        decision = self._controller(max_concurrent_sessions=2).check(
+            _FakeWorld(), WorldConfig(), live_sessions=2, free_vram_mb=None
+        )
+        assert not decision.admitted
+        assert "concurrency" in decision.reason
+
+    def test_cpu_skips_vram_check(self):
+        decision = self._controller().check(
+            _FakeWorld(vram_mb=1e9), WorldConfig(), live_sessions=0, free_vram_mb=None
+        )
+        assert decision.admitted
+
+
+class TestPreemption:
+    def test_selects_lowest_priority_then_oldest(self):
+        policy = PreemptionPolicy(mode="swap")
+        candidates = [
+            PreemptionCandidate("a", last_active_step=10, priority=1),
+            PreemptionCandidate("b", last_active_step=2, priority=0),
+            PreemptionCandidate("c", last_active_step=8, priority=0),
+        ]
+        decision = policy.select_victim(candidates)
+        assert decision is not None
+        assert decision.victim_id == "b"
+        assert decision.mode == "swap"
+
+    def test_no_candidates_returns_none(self):
+        assert PreemptionPolicy().select_victim([]) is None
+
+
+class TestSchedulerDispatch:
+    def test_step_passthrough(self):
+        sched = Scheduler(_FakeWorker())
+        state, obs = sched.step(
+            world=_FakeWorld(), state="st", action=None, modalities=["frames"], step_index=0
+        )
+        assert obs == "obs-"
+
+    def test_run_scheduled_batches_compatible_requests(self):
+        worker = _FakeWorker()
+        sched = Scheduler(worker, SchedulerConfig(max_batch_size=8))
+        world = _FakeWorld()
+        for i in range(3):
+            sched.add_request(_request(f"s{i}", world))
+        assert sched.pending == 3
+        results = sched.run_scheduled()
+        assert set(results) == {"s0", "s1", "s2"}
+        assert worker.batches == [3]
+        assert sched.pending == 0
+
+    def test_run_scheduled_separates_incompatible(self):
+        worker = _FakeWorker()
+        sched = Scheduler(worker)
+        sched.add_request(_request("a", _FakeWorld()))
+        sched.add_request(_request("b", _FakeWorld()))
+        sched.run_scheduled()
+        assert sorted(worker.batches) == [1, 1]
+
+
+def test_group_requests_rejects_bad_batch_size():
+    with pytest.raises(ValueError, match="max_batch_size"):
+        group_requests([], max_batch_size=0)

--- a/tests/serving/test_auth.py
+++ b/tests/serving/test_auth.py
@@ -11,7 +11,7 @@ from worldkernels.serving.auth import require_api_key
 
 
 def _call(dep, key):
-    return asyncio.get_event_loop().run_until_complete(dep(key=key))
+    return asyncio.run(dep(key=key))
 
 
 class TestRequireApiKey:

--- a/tests/serving/test_routes.py
+++ b/tests/serving/test_routes.py
@@ -190,12 +190,6 @@ class TestSessionRoutes:
 
 
 class TestRouteErrors:
-    def test_engine_placeholder_dependency_raises(self):
-        from worldkernels.serving.routes import _engine
-
-        with pytest.raises(RuntimeError, match="not configured"):
-            _engine()
-
     def test_world_init_error_returns_500(self, monkeypatch, client):
         from worldkernels.core.errors import WorldInitError
 
@@ -219,19 +213,13 @@ class TestRouteErrors:
         )
         assert r.status_code == 507
 
-    def test_step_session_terminated_returns_410(self, monkeypatch, client):
-        from worldkernels.core.errors import SessionTerminatedError
-
+    def test_step_session_terminated_returns_410(self, client):
         body = client.post(
             "/v1/sessions",
             json={"world": "dummy", "height": 32, "width": 32, "frames_per_step": 1},
         ).json()
         sess = client.app.state.engine.get_session(body["session_id"])
-
-        def fake_step(*a, **kw):
-            raise SessionTerminatedError(body["session_id"])
-
-        monkeypatch.setattr(sess, "step", fake_step)
+        sess.close()
         r = client.post(f"/v1/sessions/{body['session_id']}/step", json={"action_type": "null"})
         assert r.status_code == 410
 
@@ -244,10 +232,10 @@ class TestRouteErrors:
         ).json()
         sess = client.app.state.engine.get_session(body["session_id"])
 
-        def fake_step(*a, **kw):
+        def fake_transition(*a, **kw):
             raise WorldKernelError("internal")
 
-        monkeypatch.setattr(sess, "step", fake_step)
+        monkeypatch.setattr(sess._world, "transition", fake_transition)
         r = client.post(f"/v1/sessions/{body['session_id']}/step", json={"action_type": "null"})
         assert r.status_code == 500
 
@@ -281,7 +269,7 @@ class TestHelpers:
             frames=[b"\x01\x02"],
             stage_timing=StageTiming(encode_action_ms=1.0),
         )
-        out = _observation_to_dict(obs, "s1", 1)
+        out = _observation_to_dict(obs, "s1")
         assert out["session_id"] == "s1"
         assert out["frames"] == ["AQI="]
         assert out["num_frames"] == 1
@@ -291,7 +279,7 @@ class TestHelpers:
         from worldkernels.core.observation import Observation
 
         obs = Observation(step_index=0, generation_time_ms=0.0)
-        out = _observation_to_dict(obs, "s1", 0)
+        out = _observation_to_dict(obs, "s1")
         assert "frames" not in out
         assert "num_frames" not in out
         assert "stage_timing" not in out
@@ -300,6 +288,6 @@ class TestHelpers:
         from worldkernels.core.observation import Observation
 
         obs = Observation(step_index=0, generation_time_ms=0.0, frames=[42, b"x"])
-        out = _observation_to_dict(obs, "s1", 0)
+        out = _observation_to_dict(obs, "s1")
         assert out["frames"][0] is None
         assert out["frames"][1] == "eA=="

--- a/tests/serving/test_server.py
+++ b/tests/serving/test_server.py
@@ -33,9 +33,9 @@ class TestCreateApp:
         assert app.version == "0.1.0"
 
     def test_engine_attached_to_state(self, app):
-        from worldkernels.core.engine import WorldKernel
+        from worldkernels.engine import WorldEngine
 
-        assert isinstance(app.state.engine, WorldKernel)
+        assert isinstance(app.state.engine, WorldEngine)
 
     def test_default_config_used_when_none(self):
         a = create_app(None, device="cpu")
@@ -58,9 +58,6 @@ class TestAuth:
         r = TestClient(app_with_auth).get("/health")
         assert r.status_code == 200
 
-    @pytest.mark.xfail(
-        reason="routes.configure_routes builds an auth dep but never attaches it to the router"
-    )
     def test_protected_route_requires_key(self, app_with_auth):
         r = TestClient(app_with_auth).get("/v1/worlds")
         assert r.status_code == 401

--- a/tests/serving/test_websocket.py
+++ b/tests/serving/test_websocket.py
@@ -1,7 +1,47 @@
-r"""Tests for worldkernels/serving/websocket.py (currently empty)."""
+r"""Tests for the WebSocket session-streaming route (CPU-safe)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from worldkernels.config import ServerConfig
+from worldkernels.serving.server import create_app
 
 
-def test_module_importable():
-    import worldkernels.serving.websocket as ws
+@pytest.fixture
+def client():
+    app = create_app(ServerConfig(max_sessions=4, api_key=None), device="cpu")
+    app.state.engine.load_model("dummy")
+    with TestClient(app) as c:
+        yield c
+    app.state.engine.shutdown()
 
-    assert ws is not None
+
+def _session_id(client: TestClient) -> str:
+    body = client.post(
+        "/v1/sessions",
+        json={"world": "dummy", "height": 32, "width": 32, "frames_per_step": 1},
+    ).json()
+    return body["session_id"]
+
+
+class TestWebSocketStream:
+    def test_streams_observations(self, client):
+        session_id = _session_id(client)
+        with client.websocket_connect(f"/v1/sessions/{session_id}/stream") as ws:
+            ws.send_json({"action_type": "null", "modalities": ["frames"]})
+            obs = ws.receive_json()
+            assert obs["step_index"] >= 0
+            assert "frames" in obs
+
+    def test_multiple_steps_over_one_connection(self, client):
+        session_id = _session_id(client)
+        with client.websocket_connect(f"/v1/sessions/{session_id}/stream") as ws:
+            for _ in range(3):
+                ws.send_json({"action_type": "null"})
+                ws.receive_json()
+
+    def test_unknown_session_reports_error(self, client):
+        with client.websocket_connect("/v1/sessions/ghost/stream") as ws:
+            assert "error" in ws.receive_json()

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -22,7 +22,6 @@ def test_all_exports_resolvable():
 def test_lazy_exports_match_targets():
     from worldkernels.core.action import Action
     from worldkernels.core.config import ServerConfig, WorldConfig
-    from worldkernels.core.engine import WorldKernel
     from worldkernels.core.errors import (
         CheckpointNotFoundError,
         SessionLimitError,
@@ -37,6 +36,7 @@ def test_lazy_exports_match_targets():
     )
     from worldkernels.core.observation import Observation
     from worldkernels.core.session import LatentState, Session, SessionStatus
+    from worldkernels.engine import WorldEngine
     from worldkernels.runtime.stages import (
         StageConfig,
         StageExecMode,
@@ -50,7 +50,7 @@ def test_lazy_exports_match_targets():
         "Action": Action,
         "WorldConfig": WorldConfig,
         "ServerConfig": ServerConfig,
-        "WorldKernel": WorldKernel,
+        "WorldEngine": WorldEngine,
         "Observation": Observation,
         "Session": Session,
         "SessionStatus": SessionStatus,

--- a/worldkernels/__init__.py
+++ b/worldkernels/__init__.py
@@ -9,7 +9,7 @@ except ImportError:
     __version_tuple__ = (0, 1, 0, "dev0")
 
 __all__ = [
-    "WorldKernel",
+    "WorldEngine",
     "Session",
     "SessionStatus",
     "LatentState",
@@ -40,7 +40,7 @@ _LAZY_IMPORTS: dict[str, tuple[str, str]] = {
     "Action": ("worldkernels.core.action", "Action"),
     "WorldConfig": ("worldkernels.core.config", "WorldConfig"),
     "ServerConfig": ("worldkernels.core.config", "ServerConfig"),
-    "WorldKernel": ("worldkernels.core.engine", "WorldKernel"),
+    "WorldEngine": ("worldkernels.engine", "WorldEngine"),
     "Observation": ("worldkernels.core.observation", "Observation"),
     "Session": ("worldkernels.core.session", "Session"),
     "SessionStatus": ("worldkernels.core.session", "SessionStatus"),

--- a/worldkernels/cli/bench.py
+++ b/worldkernels/cli/bench.py
@@ -6,7 +6,7 @@ import time
 from contextlib import contextmanager
 from typing import Generator
 
-from worldkernels import Action, WorldConfig, WorldKernel
+from worldkernels import Action, WorldConfig, WorldEngine
 from worldkernels.core.session import Session
 
 
@@ -18,9 +18,9 @@ def bench_env(
     height: int = 64,
     width: int = 64,
     num_sessions: int = 1,
-) -> Generator[tuple[WorldKernel, list[Session]], None, None]:
+) -> Generator[tuple[WorldEngine, list[Session]], None, None]:
     r"""Shared setup/teardown for benchmark commands."""
-    wk = WorldKernel(device=device, max_sessions=max_sessions)
+    wk = WorldEngine(device=device, max_sessions=max_sessions)
     wk.load_model(world)
     world_key = world.split("/")[-1]
     config = WorldConfig(height=height, width=width, frames_per_step=1)
@@ -104,13 +104,13 @@ def run_vram(
     print("-" * 28)
     for h, w in pairs:
         cfg = WorldConfig(height=h, width=w)
-        vram = instance.estimate_vram_mb(cfg)
+        vram = instance.profile_vram(cfg)
         print(f"  {h:4d}x{w:<4d}      {vram:8.1f}")
 
 
 def run_startup(world: str, device: str) -> None:
     t0 = time.perf_counter()
-    wk = WorldKernel(device=device)
+    wk = WorldEngine(device=device)
     t_engine = time.perf_counter() - t0
 
     t1 = time.perf_counter()

--- a/worldkernels/cli/model.py
+++ b/worldkernels/cli/model.py
@@ -87,7 +87,7 @@ def run_inspect(model_id: str, device: str = "cpu", config_json: str | None = No
 
         world = cls()
         world.initialize(device=device, dtype=torch.float32 if device == "cpu" else torch.bfloat16)
-        vram = world.estimate_vram_mb(cfg)
+        vram = world.profile_vram(cfg)
         print()
         print(
             f"VRAM estimate:      {vram:.1f} MB  (config: {cfg.height}x{cfg.width}, "

--- a/worldkernels/cli/run.py
+++ b/worldkernels/cli/run.py
@@ -23,13 +23,13 @@ def run_session(
     prompt: str | None = None,
     model_kwargs: dict[str, Any] | None = None,
 ) -> None:
-    from worldkernels import Action, WorldConfig, WorldKernel
+    from worldkernels import Action, WorldConfig, WorldEngine
 
     valid_formats = ("frames", "video", "both")
     if output_format not in valid_formats:
         raise ValueError(f"--output-format must be one of {valid_formats}, got '{output_format}'")
 
-    wk = WorldKernel(device=device)
+    wk = WorldEngine(device=device)
     world_key = world.split("/")[-1]
     wk.load_model(world, **(model_kwargs or {}))
 

--- a/worldkernels/cli/serve.py
+++ b/worldkernels/cli/serve.py
@@ -28,9 +28,9 @@ def run_serve(
     app = create_app(cfg, device=device)
 
     if model is not None:
-        from worldkernels.core.engine import WorldKernel
+        from worldkernels.engine import WorldEngine
 
-        engine: WorldKernel = app.state.engine
+        engine: WorldEngine = app.state.engine
         print(f"Pre-loading model: {model}")
         engine.load_model(model, **(model_kwargs or {}))
         print(f"Model '{model}' ready.")

--- a/worldkernels/core/__init__.py
+++ b/worldkernels/core/__init__.py
@@ -1,8 +1,7 @@
-"""Core kernel: engine, session lifecycle, data types, and error hierarchy."""
+"""Core data types: session lifecycle, action, observation, error hierarchy."""
 
 from worldkernels.core.action import Action
 from worldkernels.core.config import ServerConfig, WorldConfig
-from worldkernels.core.engine import WorldKernel
 from worldkernels.core.errors import (
     CheckpointNotFoundError,
     SessionLimitError,
@@ -34,7 +33,6 @@ __all__ = [
     "WorldAlreadyLoadedError",
     "WorldConfig",
     "WorldInitError",
-    "WorldKernel",
     "WorldKernelError",
     "WorldNotFoundError",
 ]

--- a/worldkernels/core/request.py
+++ b/worldkernels/core/request.py
@@ -1,0 +1,40 @@
+r"""A scheduled unit of execution work."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from worldkernels.core.action import Action
+    from worldkernels.core.session import LatentState
+    from worldkernels.worlds.base import WorldModel
+
+__all__ = ["StepRequest"]
+
+
+@dataclass
+class StepRequest:
+    r"""One simulation step queued for the scheduler.
+
+    Carries everything the worker needs to advance one session by a step.
+    Transient: the persistent ``Session`` state lives in the engine's session
+    registry; the request only references it.
+
+    Args:
+        session_id: Owning session (empty for engine-internal calls).
+        world: The world model to run.
+        state: Current latent state.
+        action: Action to apply.
+        modalities: Observation modalities to decode.
+        step_index: Monotonic step counter.
+        decode: If False, skip the decode stage.
+    """
+
+    session_id: str
+    world: WorldModel
+    state: LatentState
+    action: Action
+    modalities: list[str] = field(default_factory=lambda: ["frames"])
+    step_index: int = 0
+    decode: bool = True

--- a/worldkernels/core/session.py
+++ b/worldkernels/core/session.py
@@ -13,8 +13,8 @@ if TYPE_CHECKING:
     from worldkernels.core.action import Action
     from worldkernels.core.config import WorldConfig
     from worldkernels.core.observation import Observation
-    from worldkernels.runtime.executor import Executor
-    from worldkernels.worlds.base import AbstractWorld
+    from worldkernels.scheduler import Scheduler
+    from worldkernels.worlds.base import WorldModel
 
 
 class SessionStatus(str, Enum):
@@ -78,9 +78,9 @@ class Session:
     # Checkpoints: checkpoint_id -> LatentState snapshot
     _checkpoints: dict[str, LatentState] = field(default_factory=dict, repr=False)
 
-    # Runtime references (injected by WorldKernel, not serialized)
-    _world: AbstractWorld | None = field(default=None, repr=False)
-    _executor: Executor | None = field(default=None, repr=False)
+    # Runtime references (injected by WorldEngine, not serialized)
+    _world: WorldModel | None = field(default=None, repr=False)
+    _scheduler: Scheduler | None = field(default=None, repr=False)
 
     # ---- core hot path ---------------------------------------------------
 
@@ -108,16 +108,16 @@ class Session:
         if self.status == SessionStatus.PAUSED:
             raise SessionPausedError(self.session_id)
 
-        if self._world is None or self._executor is None:
+        if self._world is None or self._scheduler is None:
             raise RuntimeError(
                 "Session not bound to a world model. "
-                "Create sessions via WorldKernel.create_session()."
+                "Create sessions via WorldEngine.create_session()."
             )
 
         if modalities is None:
             modalities = ["frames"]
 
-        new_state, obs = self._executor.step(
+        new_state, obs = self._scheduler.step(
             world=self._world,
             state=self.state,
             action=action,
@@ -157,7 +157,7 @@ class Session:
             seed=self.seed,
             parent_session_id=self.session_id,
             _world=self._world,
-            _executor=self._executor,
+            _scheduler=self._scheduler,
         )
 
     def close(self) -> None:

--- a/worldkernels/distributed/cfg_parallel.py
+++ b/worldkernels/distributed/cfg_parallel.py
@@ -1,0 +1,58 @@
+r"""Classifier-free-guidance parallelism.
+
+A diffusion step under CFG runs the transformer twice — once on the conditional
+input, once on the unconditional. With ``cfg_parallel_size == 2`` the two
+forwards run on separate ranks and their outputs are gathered, halving the
+per-step latency of the guided forward. With size 1 both run locally.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+import torch
+
+from worldkernels.distributed.parallel_state import (
+    get_cfg_parallel_group,
+    get_cfg_parallel_rank,
+    get_cfg_parallel_world_size,
+)
+
+__all__ = ["CFGParallelMixin"]
+
+
+class CFGParallelMixin:
+    r"""Mixin giving a pipeline a CFG-parallel guided forward.
+
+    The host pipeline calls `cfg_parallel_forward()` with a model callable
+    and the conditional / unconditional keyword arguments.
+    """
+
+    @staticmethod
+    def cfg_parallel_enabled() -> bool:
+        return get_cfg_parallel_world_size() == 2
+
+    @staticmethod
+    def cfg_parallel_forward(
+        model: Callable[..., torch.Tensor],
+        cond_kwargs: dict,
+        uncond_kwargs: dict,
+        guidance_scale: float,
+    ) -> torch.Tensor:
+        r"""Run the guided forward, splitting cond/uncond across CFG ranks.
+
+        Returns the guided prediction
+        \( \epsilon_u + s\,(\epsilon_c - \epsilon_u) \) for guidance scale \(s\).
+        """
+        if get_cfg_parallel_world_size() == 1:
+            cond = model(**cond_kwargs)
+            uncond = model(**uncond_kwargs)
+            return uncond + guidance_scale * (cond - uncond)
+
+        import torch.distributed as dist
+
+        local = model(**(cond_kwargs if get_cfg_parallel_rank() == 0 else uncond_kwargs))
+        gathered = [torch.empty_like(local), torch.empty_like(local)]
+        dist.all_gather(gathered, local.contiguous(), group=get_cfg_parallel_group())
+        cond, uncond = gathered[0], gathered[1]
+        return uncond + guidance_scale * (cond - uncond)

--- a/worldkernels/distributed/communication.py
+++ b/worldkernels/distributed/communication.py
@@ -1,0 +1,42 @@
+r"""Collective communication wrappers.
+
+Every collective is an identity no-op when its axis has world size 1, so
+single-GPU code paths carry no distributed overhead and need no guards at the
+call site.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from worldkernels.distributed.parallel_state import (
+    get_tensor_parallel_group,
+    get_tensor_parallel_world_size,
+)
+
+__all__ = [
+    "tensor_parallel_all_reduce",
+    "tensor_parallel_all_gather",
+]
+
+
+def tensor_parallel_all_reduce(tensor: torch.Tensor) -> torch.Tensor:
+    r"""Sum ``tensor`` across the tensor-parallel group, in place."""
+    if get_tensor_parallel_world_size() == 1:
+        return tensor
+    import torch.distributed as dist
+
+    dist.all_reduce(tensor, group=get_tensor_parallel_group())
+    return tensor
+
+
+def tensor_parallel_all_gather(tensor: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    r"""Gather ``tensor`` across the tensor-parallel group, concatenating on ``dim``."""
+    world_size = get_tensor_parallel_world_size()
+    if world_size == 1:
+        return tensor
+    import torch.distributed as dist
+
+    shards = [torch.empty_like(tensor) for _ in range(world_size)]
+    dist.all_gather(shards, tensor.contiguous(), group=get_tensor_parallel_group())
+    return torch.cat(shards, dim=dim)

--- a/worldkernels/distributed/sequence_parallel/__init__.py
+++ b/worldkernels/distributed/sequence_parallel/__init__.py
@@ -1,0 +1,8 @@
+r"""Sequence-parallel primitives: Ulysses all-to-all and ring rotation."""
+
+from __future__ import annotations
+
+from worldkernels.distributed.sequence_parallel.ring import ring_rotate
+from worldkernels.distributed.sequence_parallel.ulysses import ulysses_all_to_all
+
+__all__ = ["ulysses_all_to_all", "ring_rotate"]

--- a/worldkernels/distributed/sequence_parallel/ring.py
+++ b/worldkernels/distributed/sequence_parallel/ring.py
@@ -1,0 +1,48 @@
+r"""Ring sequence parallelism.
+
+Ring attention keeps the sequence sharded across ranks and circulates each
+rank's key/value block around a ring, accumulating attention with an online
+softmax so no rank ever materializes the full sequence. `ring_rotate()` is
+the communication primitive — one hop around the ring; the online-softmax
+accumulation loop lives in the attention backend that calls it.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from worldkernels.distributed.parallel_state import (
+    get_sequence_parallel_group,
+    get_sequence_parallel_rank,
+    get_sequence_parallel_world_size,
+)
+
+__all__ = ["ring_rotate"]
+
+
+def ring_rotate(tensor: torch.Tensor) -> torch.Tensor:
+    r"""Send ``tensor`` to the next rank and return the tensor from the previous one.
+
+    One hop of the ring: rank \(r\) sends to \(r{+}1\) and receives from
+    \(r{-}1\) (modulo the ring size). Identity when sequence-parallel world
+    size is 1.
+    """
+    world_size = get_sequence_parallel_world_size()
+    if world_size == 1:
+        return tensor
+    import torch.distributed as dist
+
+    group = get_sequence_parallel_group()
+    rank = get_sequence_parallel_rank()
+    ranks = dist.get_process_group_ranks(group)
+    send_to = ranks[(rank + 1) % world_size]
+    recv_from = ranks[(rank - 1) % world_size]
+
+    recv = torch.empty_like(tensor)
+    ops = [
+        dist.P2POp(dist.isend, tensor.contiguous(), send_to, group),
+        dist.P2POp(dist.irecv, recv, recv_from, group),
+    ]
+    for work in dist.batch_isend_irecv(ops):
+        work.wait()
+    return recv

--- a/worldkernels/distributed/sequence_parallel/ulysses.py
+++ b/worldkernels/distributed/sequence_parallel/ulysses.py
@@ -1,0 +1,52 @@
+r"""Ulysses sequence parallelism.
+
+Ulysses shards the sequence dimension across ranks for the linear layers and,
+inside attention, transposes that sharding onto the head dimension with an
+all-to-all so each rank computes full-sequence attention for a slice of the
+heads. Two all-to-alls bracket the attention call: sequence-sharded ->
+head-sharded before, head-sharded -> sequence-sharded after.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from worldkernels.distributed.parallel_state import (
+    get_sequence_parallel_group,
+    get_sequence_parallel_world_size,
+)
+
+__all__ = ["ulysses_all_to_all"]
+
+
+def ulysses_all_to_all(
+    x: torch.Tensor,
+    *,
+    scatter_dim: int,
+    gather_dim: int,
+) -> torch.Tensor:
+    r"""All-to-all redistribution across the sequence-parallel group.
+
+    Splits ``x`` into equal chunks along ``scatter_dim``, exchanges one chunk
+    with every rank, and concatenates the received chunks along ``gather_dim``.
+    Identity when sequence-parallel world size is 1.
+
+    Args:
+        x: Tensor sharded along ``scatter_dim``.
+        scatter_dim: Dimension to split and send.
+        gather_dim: Dimension to concatenate received chunks on.
+    """
+    world_size = get_sequence_parallel_world_size()
+    if world_size == 1:
+        return x
+    import torch.distributed as dist
+
+    if x.shape[scatter_dim] % world_size != 0:
+        raise ValueError(
+            f"scatter dim {scatter_dim} (size {x.shape[scatter_dim]}) not divisible "
+            f"by sequence-parallel world size {world_size}"
+        )
+    send = [c.contiguous() for c in x.chunk(world_size, dim=scatter_dim)]
+    recv = [torch.empty_like(send[0]) for _ in range(world_size)]
+    dist.all_to_all(recv, send, group=get_sequence_parallel_group())
+    return torch.cat(recv, dim=gather_dim)

--- a/worldkernels/engine/__init__.py
+++ b/worldkernels/engine/__init__.py
@@ -1,0 +1,22 @@
+r"""Engine layer: request intake, model lifecycle, session registry."""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+__all__ = ["WorldEngine", "AsyncEngine"]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "WorldEngine": ("worldkernels.engine.world_engine", "WorldEngine"),
+    "AsyncEngine": ("worldkernels.engine.async_engine", "AsyncEngine"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/engine/async_engine.py
+++ b/worldkernels/engine/async_engine.py
@@ -1,0 +1,153 @@
+r"""Async engine — the continuous-batching serving front-end.
+
+Wraps a `WorldEngine` with an async API and a background drain loop. A
+``step`` call enqueues a `StepRequest` and awaits a future; the drain
+loop wakes every ``batch_window`` and dispatches all queued requests as
+compatibility-group batches through the scheduler. Concurrent requests for the
+same world thus share a batched forward pass — genuine continuous batching.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from worldkernels.core.errors import (
+    SessionNotFoundError,
+    SessionPausedError,
+    SessionTerminatedError,
+)
+from worldkernels.runtime import metrics
+
+if TYPE_CHECKING:
+    from worldkernels.config import WorldConfig
+    from worldkernels.core.action import Action
+    from worldkernels.core.observation import Observation
+    from worldkernels.core.session import Session
+    from worldkernels.engine.world_engine import WorldEngine
+
+__all__ = ["AsyncEngine"]
+
+
+class AsyncEngine:
+    r"""Async, continuous-batching wrapper around a `WorldEngine`.
+
+    Args:
+        engine: The synchronous engine to drive.
+        batch_window: Seconds to accumulate requests before a drain; the
+            micro-batching window.
+    """
+
+    def __init__(self, engine: "WorldEngine", *, batch_window: float = 0.005) -> None:
+        self.engine = engine
+        self.batch_window = batch_window
+        self._pending: dict[str, asyncio.Future] = {}
+        self._drain_task: asyncio.Task | None = None
+        self._closed = False
+
+    async def load_model(self, model_id: str, **kwargs: Any) -> None:
+        await asyncio.to_thread(self.engine.load_model, model_id, **kwargs)
+
+    async def unload_model(self, name: str) -> None:
+        await asyncio.to_thread(self.engine.unload_model, name)
+
+    async def create_session(
+        self,
+        world: str,
+        config: "WorldConfig | None" = None,
+        seed: int | None = None,
+    ) -> "Session":
+        session = await asyncio.to_thread(self.engine.create_session, world, config, seed)
+        metrics.set_active_sessions(len(self.engine.list_sessions()))
+        return session
+
+    async def close_session(self, session_id: str) -> None:
+        await asyncio.to_thread(self.engine.close_session, session_id)
+        metrics.set_active_sessions(len(self.engine.list_sessions()))
+
+    async def step(
+        self,
+        session_id: str,
+        action: "Action",
+        modalities: list[str] | None = None,
+        decode: bool = True,
+    ) -> "Observation":
+        r"""Execute one step, batched with other concurrent steps."""
+        from worldkernels.core.request import StepRequest
+        from worldkernels.core.session import SessionStatus
+
+        session = self.engine.get_session(session_id)
+        if session is None:
+            raise SessionNotFoundError(session_id)
+        if session.status is SessionStatus.TERMINATED:
+            raise SessionTerminatedError(session_id)
+        if session.status is SessionStatus.PAUSED:
+            raise SessionPausedError(session_id)
+        if session_id in self._pending:
+            raise RuntimeError(f"a step is already in flight for session {session_id!r}")
+
+        self._ensure_drain_loop()
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[session_id] = future
+        self.engine._scheduler.add_request(
+            StepRequest(
+                session_id=session_id,
+                world=session._world,  # type: ignore[arg-type]
+                state=session.state,
+                action=action,
+                modalities=modalities or ["frames"],
+                step_index=session.step_index,
+                decode=decode,
+            )
+        )
+        return await future
+
+    async def shutdown(self) -> None:
+        self._closed = True
+        if self._drain_task is not None:
+            self._drain_task.cancel()
+        for future in self._pending.values():
+            if not future.done():
+                future.cancel()
+        self._pending.clear()
+        await asyncio.to_thread(self.engine.shutdown)
+
+    def _ensure_drain_loop(self) -> None:
+        if self._drain_task is None or self._drain_task.done():
+            self._drain_task = asyncio.create_task(self._drain_loop())
+
+    async def _drain_loop(self) -> None:
+        scheduler = self.engine._scheduler
+        while not self._closed:
+            await asyncio.sleep(self.batch_window)
+            batch = scheduler.pending
+            if not batch:
+                continue
+            try:
+                results = await asyncio.to_thread(scheduler.run_scheduled)
+            except Exception as exc:  # noqa: BLE001 - surface compute errors to callers
+                self._fail_pending(exc)
+                continue
+            metrics.observe_batch(batch)
+            for session_id, (new_state, obs) in results.items():
+                self._resolve(session_id, new_state, obs)
+
+    def _fail_pending(self, exc: BaseException) -> None:
+        r"""Fail every awaiting step with ``exc`` rather than hang on a dead batch."""
+        for future in self._pending.values():
+            if not future.done():
+                future.set_exception(exc)
+        self._pending.clear()
+
+    def _resolve(self, session_id: str, new_state: Any, obs: "Observation") -> None:
+        session = self.engine.get_session(session_id)
+        if session is not None:
+            session.state = new_state
+            session.step_index += 1
+            session.last_active_at = datetime.now()
+        frames = len(obs.frames) if obs.frames is not None else 0
+        metrics.observe_step(obs.generation_time_ms / 1000.0, frames=frames)
+        future = self._pending.pop(session_id, None)
+        if future is not None and not future.done():
+            future.set_result(obs)

--- a/worldkernels/engine/world_engine.py
+++ b/worldkernels/engine/world_engine.py
@@ -1,4 +1,9 @@
-"""WorldKernel main engine class."""
+r"""WorldEngine — the request-and-lifecycle layer.
+
+Owns the world registry and session registry, resolves and loads models, and
+creates sessions. Execution is delegated to a `Scheduler`, which
+dispatches to a `Worker`; the engine itself runs no model compute.
+"""
 
 from __future__ import annotations
 
@@ -16,9 +21,9 @@ from worldkernels.core.errors import (
 )
 
 if TYPE_CHECKING:
-    from worldkernels.core.config import WorldConfig
+    from worldkernels.config import WorldConfig
     from worldkernels.core.session import Session
-    from worldkernels.worlds.base import AbstractWorld
+    from worldkernels.worlds.base import WorldModel
 
 log = logging.getLogger(__name__)
 
@@ -27,18 +32,17 @@ def _default_dtype(device: str) -> torch.dtype:
     if device == "cpu":
         return torch.float32
     if torch.cuda.is_available():
-        cap = torch.cuda.get_device_capability()
-        if cap >= (8, 0):
+        if torch.cuda.get_device_capability() >= (8, 0):
             return torch.bfloat16
         return torch.float16
     return torch.float32
 
 
-class WorldKernel:
-    r"""GPU-first world model simulation engine.
+class WorldEngine:
+    r"""GPU-first world-model simulation engine.
 
     Args:
-        device: Target device ("cuda", "cpu").
+        device: Target device (``"cuda"``, ``"cpu"``, or ``"cuda:N"``).
         max_sessions: Maximum concurrent sessions.
         offload_idle: Whether to offload idle session state.
     """
@@ -54,26 +58,21 @@ class WorldKernel:
         self.offload_idle = offload_idle
         self.dtype = _default_dtype(device)
 
-        # world_alias -> instantiated AbstractWorld
-        self._worlds: dict[str, AbstractWorld] = {}
+        self._worlds: dict[str, WorldModel] = {}
         self._sessions: dict[str, Session] = {}
 
-        # Shared executor (one per engine for now)
-        from worldkernels.runtime.executor import Executor
+        from worldkernels.scheduler import Scheduler
+        from worldkernels.worker import Worker
 
-        self._executor = Executor(
-            device=device,
-            dtype=self.dtype,
-        )
+        self._worker = Worker(device=device, dtype=self.dtype)
+        self._scheduler = Scheduler(self._worker)
 
         log.info(
-            "WorldKernel initialized: device=%s, dtype=%s, max_sessions=%d",
+            "WorldEngine initialized: device=%s, dtype=%s, max_sessions=%d",
             device,
             self.dtype,
             max_sessions,
         )
-
-    # ---- world loading ---------------------------------------------------
 
     def load_model(
         self,
@@ -84,18 +83,17 @@ class WorldKernel:
     ) -> None:
         r"""Load a world model by short name, HF repo ID, or registry name.
 
-        Resolution order: hub (short names + HF IDs) -> worlds registry.
-        Hub default kwargs are merged with user kwargs (user wins).
+        Resolution order: hub (short names + HF IDs) -> worlds registry. Hub
+        default kwargs are merged with user kwargs (user wins). Generators are
+        resolved to `GeneratorWorld` automatically.
 
         Args:
-            model_id: Short name (e.g. "dreamdojo-2b-gr1"), HF repo ID
-                (e.g. "nvidia/DreamDojo"), or adapter registry name.
+            model_id: Short name, HF repo ID, or adapter registry name.
             alias: Optional short name for the loaded model.
             trust_remote_code: Allow custom code from HF Hub.
-            **kwargs: Forwarded to the adapter constructor (e.g.
-                ``variant``, ``ckpt_path`` for DreamDojo).
+            **kwargs: Forwarded to the world constructor.
         """
-        from worldkernels.core.config import WorldConfig as WC
+        from worldkernels.config import WorldConfig as WC
         from worldkernels.worlds.hub import ensure_model_deps, resolve_model
         from worldkernels.worlds.registry import get_world_class
 
@@ -103,7 +101,6 @@ class WorldKernel:
         adapter_name, merged_kwargs = resolve_model(model_id, **kwargs)
 
         key = alias or model_id.split("/")[-1]
-
         if key in self._worlds:
             raise WorldAlreadyLoadedError(key)
 
@@ -112,7 +109,7 @@ class WorldKernel:
         except KeyError:
             raise WorldNotFoundError(model_id)
 
-        world: AbstractWorld = world_cls(**merged_kwargs)
+        world: WorldModel = world_cls(**merged_kwargs)
         try:
             world.initialize(device=self.device, dtype=self.dtype)
         except Exception as exc:
@@ -123,8 +120,6 @@ class WorldKernel:
         self._worlds[key] = world
         log.info("Loaded world: %s (class=%s)", key, world_cls.__qualname__)
 
-    # ---- session management ----------------------------------------------
-
     def create_session(
         self,
         world: str,
@@ -132,35 +127,32 @@ class WorldKernel:
         seed: int | None = None,
     ) -> Session:
         r"""Create a new simulation session bound to a loaded world model."""
-        from worldkernels.core.config import WorldConfig as WC
+        from worldkernels.config import WorldConfig as WC
         from worldkernels.core.session import Session
 
         if world not in self._worlds:
             raise WorldNotFoundError(world)
-
         if len(self._sessions) >= self.max_sessions:
             raise SessionLimitError(self.max_sessions)
 
         cfg = config or WC()
         actual_seed = seed if seed is not None else 0
-
         world_instance = self._worlds[world]
 
-        vram_mb = world_instance.estimate_vram_mb(cfg)
+        vram_mb = world_instance.profile_vram(cfg)
         if self.device.startswith("cuda") and torch.cuda.is_available():
             free_mb = torch.cuda.mem_get_info()[0] / (1024 * 1024)
             if vram_mb > free_mb:
                 raise VRAMExhaustedError(required_mb=vram_mb, available_mb=free_mb)
 
         initial_state = world_instance.create_initial_state(cfg, actual_seed)
-
         session = Session(
             world_id=world,
             config=cfg,
             state=initial_state,
             seed=actual_seed,
             _world=world_instance,
-            _executor=self._executor,
+            _scheduler=self._scheduler,
         )
         self._sessions[session.session_id] = session
         log.info("Created session: %s (world=%s)", session.session_id, world)
@@ -184,8 +176,7 @@ class WorldKernel:
         r"""Unload a world model and close all its sessions."""
         if name not in self._worlds:
             raise WorldNotFoundError(name)
-        sessions_to_close = [sid for sid, sess in self._sessions.items() if sess.world_id == name]
-        for sid in sessions_to_close:
+        for sid in [s for s, sess in self._sessions.items() if sess.world_id == name]:
             self.close_session(sid)
         del self._worlds[name]
         log.info("Unloaded world: %s", name)
@@ -195,4 +186,4 @@ class WorldKernel:
             session.close()
         self._sessions.clear()
         self._worlds.clear()
-        log.info("WorldKernel shut down.")
+        log.info("WorldEngine shut down.")

--- a/worldkernels/runtime/attention/__init__.py
+++ b/worldkernels/runtime/attention/__init__.py
@@ -1,0 +1,37 @@
+r"""Pluggable attention backends and selection."""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+__all__ = [
+    "AttentionBackend",
+    "AttentionMetadata",
+    "SDPABackend",
+    "FlashAttentionBackend",
+    "select_attention_backend",
+]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "AttentionBackend": ("worldkernels.runtime.attention.backend", "AttentionBackend"),
+    "AttentionMetadata": ("worldkernels.runtime.attention.backend", "AttentionMetadata"),
+    "SDPABackend": ("worldkernels.runtime.attention.backends.sdpa", "SDPABackend"),
+    "FlashAttentionBackend": (
+        "worldkernels.runtime.attention.backends.flash",
+        "FlashAttentionBackend",
+    ),
+    "select_attention_backend": (
+        "worldkernels.runtime.attention.selector",
+        "select_attention_backend",
+    ),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/runtime/attention/backend.py
+++ b/worldkernels/runtime/attention/backend.py
@@ -1,0 +1,50 @@
+r"""Pluggable attention backend interface.
+
+A backend computes scaled dot-product attention for query/key/value tensors in
+the ``(batch, seq, heads, head_dim)`` layout — the layout diffusers and
+flash-attn use. Backends are selected per hardware by
+`select_attention_backend()` and
+read from the active `ForwardContext`.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, ClassVar
+
+if TYPE_CHECKING:
+    import torch
+
+__all__ = ["AttentionMetadata", "AttentionBackend"]
+
+
+@dataclass
+class AttentionMetadata:
+    r"""Per-forward attention state threaded via the forward context.
+
+    Args:
+        is_causal: Whether the attention mask is causal (streaming worlds).
+        scale: Softmax scale; ``None`` uses \(1/\sqrt{d}\).
+    """
+
+    is_causal: bool = False
+    scale: float | None = None
+
+
+class AttentionBackend(ABC):
+    r"""Computes attention over ``(batch, seq, heads, head_dim)`` tensors."""
+
+    name: ClassVar[str]
+
+    @abstractmethod
+    def forward(
+        self,
+        query: "torch.Tensor",
+        key: "torch.Tensor",
+        value: "torch.Tensor",
+        *,
+        is_causal: bool = False,
+        scale: float | None = None,
+    ) -> "torch.Tensor":
+        r"""Return the attention output in ``(batch, seq, heads, head_dim)`` layout."""

--- a/worldkernels/runtime/attention/backends/__init__.py
+++ b/worldkernels/runtime/attention/backends/__init__.py
@@ -1,0 +1,25 @@
+r"""Attention backend implementations."""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+__all__ = ["SDPABackend", "FlashAttentionBackend"]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "SDPABackend": ("worldkernels.runtime.attention.backends.sdpa", "SDPABackend"),
+    "FlashAttentionBackend": (
+        "worldkernels.runtime.attention.backends.flash",
+        "FlashAttentionBackend",
+    ),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/runtime/attention/backends/flash.py
+++ b/worldkernels/runtime/attention/backends/flash.py
@@ -1,0 +1,42 @@
+r"""FlashAttention backend.
+
+Fast, low-memory attention on Ampere+ GPUs. Requires the optional
+``flash-attn`` package; absent it, the backend stays importable and raises an
+actionable error only when used.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import torch
+
+from worldkernels.runtime.attention.backend import AttentionBackend
+from worldkernels.utils import optional_import
+
+__all__ = ["FlashAttentionBackend"]
+
+_flash_attn = optional_import("flash_attn", "flash-attn")
+
+
+class FlashAttentionBackend(AttentionBackend):
+    r"""Attention via ``flash_attn.flash_attn_func`` (Ampere+ GPUs)."""
+
+    name: ClassVar[str] = "flash"
+
+    @staticmethod
+    def is_available() -> bool:
+        from worldkernels.utils.import_utils import PlaceholderModule
+
+        return not isinstance(_flash_attn, PlaceholderModule)
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        is_causal: bool = False,
+        scale: float | None = None,
+    ) -> torch.Tensor:
+        return _flash_attn.flash_attn_func(query, key, value, causal=is_causal, softmax_scale=scale)

--- a/worldkernels/runtime/attention/backends/sdpa.py
+++ b/worldkernels/runtime/attention/backends/sdpa.py
@@ -1,0 +1,36 @@
+r"""PyTorch scaled-dot-product-attention backend.
+
+The universal fallback: works on CPU and every GPU, no extra dependency.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+import torch
+import torch.nn.functional as F
+
+from worldkernels.runtime.attention.backend import AttentionBackend
+
+__all__ = ["SDPABackend"]
+
+
+class SDPABackend(AttentionBackend):
+    r"""Attention via ``torch.nn.functional.scaled_dot_product_attention``."""
+
+    name: ClassVar[str] = "sdpa"
+
+    def forward(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        *,
+        is_causal: bool = False,
+        scale: float | None = None,
+    ) -> torch.Tensor:
+        q = query.transpose(1, 2)
+        k = key.transpose(1, 2)
+        v = value.transpose(1, 2)
+        out = F.scaled_dot_product_attention(q, k, v, is_causal=is_causal, scale=scale)
+        return out.transpose(1, 2)

--- a/worldkernels/runtime/attention/selector.py
+++ b/worldkernels/runtime/attention/selector.py
@@ -1,0 +1,32 @@
+r"""Attention backend selection.
+
+Resolves a backend by explicit name or by the active platform's default,
+falling back to SDPA when a requested accelerated backend is unavailable.
+"""
+
+from __future__ import annotations
+
+from worldkernels.runtime.attention.backend import AttentionBackend
+
+__all__ = ["select_attention_backend"]
+
+
+def select_attention_backend(name: str | None = None) -> AttentionBackend:
+    r"""Return an attention backend instance.
+
+    Args:
+        name: ``"sdpa"`` / ``"flash"``; ``None`` uses the platform default.
+            A requested ``"flash"`` backend silently falls back to SDPA when
+            ``flash-attn`` is not installed.
+    """
+    from worldkernels.platforms import current_platform
+    from worldkernels.runtime.attention.backends import FlashAttentionBackend, SDPABackend
+
+    resolved = name or current_platform().default_attention_backend()
+    if resolved == "flash" and FlashAttentionBackend.is_available():
+        return FlashAttentionBackend()
+    if resolved == "flash":
+        return SDPABackend()
+    if resolved == "sdpa":
+        return SDPABackend()
+    raise ValueError(f"unknown attention backend {resolved!r}; available: sdpa, flash")

--- a/worldkernels/runtime/cache/__init__.py
+++ b/worldkernels/runtime/cache/__init__.py
@@ -1,0 +1,21 @@
+r"""Denoise-step caching backends."""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+__all__ = ["TeaCache"]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "TeaCache": ("worldkernels.runtime.cache.teacache", "TeaCache"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/runtime/cache/teacache.py
+++ b/worldkernels/runtime/cache/teacache.py
@@ -1,0 +1,82 @@
+r"""TeaCache — timestep-embedding-aware denoise-step caching.
+
+Across a denoise loop the transformer's per-step modulation signal changes
+slowly. TeaCache accumulates the relative L1 change of that signal; while the
+accumulated change stays below a threshold it reports that the heavy
+transformer compute can be skipped and the previous step's residual reused.
+
+This holds only the skip decision and the cached residual; the transformer
+calls `should_compute()` / `store()` around its block stack.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch
+
+__all__ = ["TeaCache"]
+
+
+class TeaCache:
+    r"""Relative-L1 step-skipping cache for a denoise loop.
+
+    Args:
+        rel_l1_threshold: Accumulated relative-L1 change at which a full
+            recompute is forced. Larger skips more steps (faster, lower quality).
+    """
+
+    def __init__(self, rel_l1_threshold: float = 0.15) -> None:
+        if rel_l1_threshold < 0:
+            raise ValueError(f"rel_l1_threshold must be >= 0, got {rel_l1_threshold}")
+        self.rel_l1_threshold = rel_l1_threshold
+        self._prev_modulation: "torch.Tensor | None" = None
+        self._cached_residual: "torch.Tensor | None" = None
+        self._accumulated = 0.0
+        self.hits = 0
+        self.misses = 0
+
+    def should_compute(self, modulation: "torch.Tensor") -> bool:
+        r"""Whether the transformer must run this step, or its residual is reused.
+
+        Updates the accumulated relative-L1 distance from the previous step's
+        modulation signal.
+        """
+        if self._prev_modulation is None or self._cached_residual is None:
+            self._prev_modulation = modulation
+            self.misses += 1
+            return True
+
+        prev = self._prev_modulation
+        rel_change = ((modulation - prev).abs().mean() / (prev.abs().mean() + 1e-8)).item()
+        self._accumulated += rel_change
+        self._prev_modulation = modulation
+
+        if self._accumulated < self.rel_l1_threshold:
+            self.hits += 1
+            return False
+        self._accumulated = 0.0
+        self.misses += 1
+        return True
+
+    def store(self, residual: "torch.Tensor") -> None:
+        r"""Cache the transformer residual from a computed step."""
+        self._cached_residual = residual
+
+    @property
+    def cached_residual(self) -> "torch.Tensor | None":
+        return self._cached_residual
+
+    @property
+    def hit_rate(self) -> float:
+        total = self.hits + self.misses
+        return self.hits / total if total else 0.0
+
+    def reset(self) -> None:
+        r"""Clear all state for a fresh denoise loop."""
+        self._prev_modulation = None
+        self._cached_residual = None
+        self._accumulated = 0.0
+        self.hits = 0
+        self.misses = 0

--- a/worldkernels/runtime/compile/__init__.py
+++ b/worldkernels/runtime/compile/__init__.py
@@ -1,0 +1,22 @@
+r"""Compilation backends: regional torch.compile and CUDA graph capture."""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+__all__ = ["regionally_compile", "CUDAGraphRunner"]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "regionally_compile": ("worldkernels.runtime.compile.torch_compile", "regionally_compile"),
+    "CUDAGraphRunner": ("worldkernels.runtime.compile.cuda_graph", "CUDAGraphRunner"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/runtime/compile/cuda_graph.py
+++ b/worldkernels/runtime/compile/cuda_graph.py
@@ -1,0 +1,71 @@
+r"""CUDA graph capture and replay.
+
+A captured graph records the GPU kernel sequence of a fixed-shape callable
+once, then replays it with near-zero CPU launch overhead — the largest win for
+the denoise loop, which runs the same transformer step tens of times. Inputs
+must keep identical shapes, dtypes, and devices across replays.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Callable
+
+if TYPE_CHECKING:
+    import torch
+
+__all__ = ["CUDAGraphRunner"]
+
+
+class CUDAGraphRunner:
+    r"""Captures one fixed-shape callable as a CUDA graph and replays it."""
+
+    def __init__(self) -> None:
+        self._graph: Any = None
+        self._static_inputs: tuple["torch.Tensor", ...] = ()
+        self._static_output: Any = None
+
+    @property
+    def is_captured(self) -> bool:
+        return self._graph is not None
+
+    def capture(
+        self,
+        fn: Callable[..., "torch.Tensor"],
+        *sample_inputs: "torch.Tensor",
+        warmup: int = 3,
+    ) -> "CUDAGraphRunner":
+        r"""Warm up and capture ``fn(*sample_inputs)`` as a CUDA graph.
+
+        Args:
+            fn: The callable to capture; must take only tensor arguments.
+            sample_inputs: Representative inputs defining the captured shapes.
+            warmup: Eager iterations before capture (lets autograd/cuDNN settle).
+        """
+        import torch
+
+        if not torch.cuda.is_available():
+            raise RuntimeError("CUDA graph capture requires a CUDA device")
+
+        warmup_stream = torch.cuda.Stream()
+        warmup_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(warmup_stream):
+            for _ in range(warmup):
+                fn(*sample_inputs)
+        torch.cuda.current_stream().wait_stream(warmup_stream)
+
+        self._static_inputs = tuple(t.clone() for t in sample_inputs)
+        self._graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(self._graph):
+            self._static_output = fn(*self._static_inputs)
+        return self
+
+    def replay(self, *inputs: "torch.Tensor") -> Any:
+        r"""Copy ``inputs`` into the captured buffers and replay the graph."""
+        if self._graph is None:
+            raise RuntimeError("graph not captured; call capture() first")
+        if len(inputs) != len(self._static_inputs):
+            raise ValueError(f"expected {len(self._static_inputs)} inputs, got {len(inputs)}")
+        for static, fresh in zip(self._static_inputs, inputs):
+            static.copy_(fresh)
+        self._graph.replay()
+        return self._static_output

--- a/worldkernels/runtime/compile/torch_compile.py
+++ b/worldkernels/runtime/compile/torch_compile.py
@@ -1,0 +1,50 @@
+r"""Regional ``torch.compile``.
+
+A video DiT is a stack of identical transformer blocks wrapped by one-off
+embedding and projection layers. Compiling only the repeated block — not the
+whole model — keeps compile time bounded and avoids recompiles when outer
+shapes vary. A module opts in by listing the attribute names of its repeated
+``nn.ModuleList``s in ``_repeated_blocks``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import torch.nn as nn
+
+__all__ = ["regionally_compile"]
+
+
+def regionally_compile(
+    module: "nn.Module",
+    *,
+    mode: str = "reduce-overhead",
+    repeated_block_attrs: list[str] | None = None,
+) -> "nn.Module":
+    r"""Compile a module's repeated blocks in place, leaving one-off ops eager.
+
+    Args:
+        module: The model to compile.
+        mode: ``torch.compile`` mode.
+        repeated_block_attrs: Attribute names of repeated ``nn.ModuleList``s.
+            Defaults to ``module._repeated_blocks``; if neither is present the
+            whole module is compiled.
+
+    Returns:
+        The same ``module``, with its repeated blocks replaced by compiled ones.
+    """
+    import torch
+
+    attrs = repeated_block_attrs or getattr(module, "_repeated_blocks", None)
+    if not attrs:
+        return torch.compile(module, mode=mode)  # type: ignore[return-value]
+
+    for attr in attrs:
+        block_list = getattr(module, attr, None)
+        if block_list is None:
+            continue
+        for i in range(len(block_list)):
+            block_list[i] = torch.compile(block_list[i], mode=mode)
+    return module

--- a/worldkernels/runtime/executor.py
+++ b/worldkernels/runtime/executor.py
@@ -19,8 +19,9 @@ from worldkernels.runtime.stages import (
 
 if TYPE_CHECKING:
     from worldkernels.core.action import Action
+    from worldkernels.core.request import StepRequest
     from worldkernels.core.session import LatentState
-    from worldkernels.worlds.base import AbstractWorld
+    from worldkernels.worlds.base import WorldModel
 
 
 class Executor:
@@ -56,7 +57,7 @@ class Executor:
     @torch.no_grad()
     def execute_encode(
         self,
-        world: AbstractWorld,
+        world: WorldModel,
         action: Action,
     ) -> StageOutput:
         r"""Stage 1: encode action to conditioning tensor."""
@@ -72,7 +73,7 @@ class Executor:
     @torch.no_grad()
     def execute_transition(
         self,
-        world: AbstractWorld,
+        world: WorldModel,
         state: LatentState,
         action_encoded: torch.Tensor,
     ) -> StageOutput:
@@ -94,7 +95,7 @@ class Executor:
     @torch.no_grad()
     def execute_decode(
         self,
-        world: AbstractWorld,
+        world: WorldModel,
         state: LatentState,
         modalities: list[str],
     ) -> StageOutput:
@@ -113,7 +114,7 @@ class Executor:
     @torch.no_grad()
     def step(
         self,
-        world: AbstractWorld,
+        world: WorldModel,
         state: LatentState,
         action: Action,
         modalities: list[str],
@@ -161,3 +162,26 @@ class Executor:
         obs.stage_timing = timing
 
         return new_state, obs
+
+    @torch.no_grad()
+    def execute_batched(
+        self,
+        requests: list[StepRequest],
+    ) -> list[tuple[LatentState, Observation]]:
+        r"""Execute a batch of step requests.
+
+        Currently iterates one request at a time; true batched forward passes
+        over a compatibility group land with the throughput step. The list
+        signature is the seam the scheduler dispatches into.
+        """
+        return [
+            self.step(
+                world=req.world,
+                state=req.state,
+                action=req.action,
+                modalities=req.modalities,
+                step_index=req.step_index,
+                decode=req.decode,
+            )
+            for req in requests
+        ]

--- a/worldkernels/runtime/memory.py
+++ b/worldkernels/runtime/memory.py
@@ -1,8 +1,0 @@
-class LatentCacheManager:
-    r"""Manages GPU memory blocks for latent states.
-
-    Sessions that share a common history prefix (branching) can share
-    latent cache blocks.
-    """
-
-    pass

--- a/worldkernels/runtime/memory/__init__.py
+++ b/worldkernels/runtime/memory/__init__.py
@@ -1,0 +1,39 @@
+r"""Memory subsystem: block allocation, KV paging, buffer pools, offloading.
+
+``TrajectoryCache`` is torch-free and eagerly exported; the tensor-backed
+managers are lazily imported.
+"""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+from worldkernels.runtime.memory.trajectory_cache import PrefixMatch, TrajectoryCache
+
+__all__ = [
+    "BlockManager",
+    "LatentPool",
+    "Offloader",
+    "MemoryTier",
+    "KVCacheManager",
+    "TrajectoryCache",
+    "PrefixMatch",
+]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "BlockManager": ("worldkernels.runtime.memory.block_manager", "BlockManager"),
+    "LatentPool": ("worldkernels.runtime.memory.latent_pool", "LatentPool"),
+    "Offloader": ("worldkernels.runtime.memory.offload", "Offloader"),
+    "MemoryTier": ("worldkernels.runtime.memory.offload", "MemoryTier"),
+    "KVCacheManager": ("worldkernels.runtime.memory.kv_cache", "KVCacheManager"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/runtime/memory/block_manager.py
+++ b/worldkernels/runtime/memory/block_manager.py
@@ -1,0 +1,99 @@
+r"""Fixed-size block (slab) allocator for latent and KV storage.
+
+Pre-allocates one contiguous slab on the device and hands out block indices,
+so steady-state operation never calls ``cudaMalloc`` / ``cudaFree``. Blocks are
+reference-counted, which makes copy-on-write sharing (session branching,
+trajectory-prefix reuse) a refcount bump rather than a copy.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ["BlockManager"]
+
+
+class BlockManager:
+    r"""Slab allocator handing out fixed-shape blocks of a pre-allocated tensor.
+
+    Args:
+        block_shape: Shape of one block (the per-block trailing dims).
+        num_blocks: Number of blocks in the slab.
+        device: Device the slab lives on.
+        dtype: Slab dtype.
+    """
+
+    def __init__(
+        self,
+        *,
+        block_shape: "Sequence[int]",
+        num_blocks: int,
+        device: str,
+        dtype: torch.dtype,
+    ) -> None:
+        if num_blocks < 1:
+            raise ValueError(f"num_blocks must be >= 1, got {num_blocks}")
+        self.block_shape = tuple(block_shape)
+        self.num_blocks = num_blocks
+        self.device = device
+        self.dtype = dtype
+        self._slab = torch.empty((num_blocks, *self.block_shape), device=device, dtype=dtype)
+        self._free: list[int] = list(reversed(range(num_blocks)))
+        self._refcount: dict[int, int] = {}
+
+    @property
+    def num_free(self) -> int:
+        return len(self._free)
+
+    @property
+    def num_allocated(self) -> int:
+        return self.num_blocks - len(self._free)
+
+    def allocate(self, n_blocks: int = 1) -> list[int]:
+        r"""Reserve ``n_blocks`` blocks, returning their ids (refcount 1)."""
+        if n_blocks < 0:
+            raise ValueError(f"n_blocks must be >= 0, got {n_blocks}")
+        if n_blocks > len(self._free):
+            raise MemoryError(
+                f"block pool exhausted: requested {n_blocks}, {len(self._free)} free "
+                f"of {self.num_blocks}"
+            )
+        ids = [self._free.pop() for _ in range(n_blocks)]
+        for block_id in ids:
+            self._refcount[block_id] = 1
+        return ids
+
+    def block(self, block_id: int) -> torch.Tensor:
+        r"""Return the tensor view of block ``block_id``."""
+        return self._slab[block_id]
+
+    def share(self, block_ids: "Sequence[int]") -> list[int]:
+        r"""Copy-on-write share: bump refcounts and return the same ids."""
+        for block_id in block_ids:
+            self._refcount[block_id] += 1
+        return list(block_ids)
+
+    def free(self, block_ids: "Sequence[int]") -> None:
+        r"""Release a reference to each block; return it to the free list at zero."""
+        for block_id in block_ids:
+            count = self._refcount.get(block_id, 0)
+            if count <= 0:
+                continue
+            if count == 1:
+                del self._refcount[block_id]
+                self._free.append(block_id)
+            else:
+                self._refcount[block_id] = count - 1
+
+    def refcount(self, block_id: int) -> int:
+        return self._refcount.get(block_id, 0)
+
+    def reset(self) -> None:
+        r"""Release every block."""
+        self._free = list(reversed(range(self.num_blocks)))
+        self._refcount.clear()

--- a/worldkernels/runtime/memory/kv_cache.py
+++ b/worldkernels/runtime/memory/kv_cache.py
@@ -1,0 +1,63 @@
+r"""Paged KV cache for causal world models.
+
+Each session's KV cache is a chain of fixed-size blocks drawn from a
+`BlockManager`. Branching a
+session forks the block table copy-on-write: blocks are shared (a refcount
+bump) until one branch writes past the divergence point.
+
+Only causal worlds (``transition_mode == CAUSAL``) hold a KV cache;
+bidirectional worlds pay none of this cost.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from worldkernels.runtime.memory.block_manager import BlockManager
+
+__all__ = ["KVCacheManager"]
+
+
+class KVCacheManager:
+    r"""Per-session paged KV-cache block tables over a shared block pool.
+
+    Args:
+        block_manager: The block pool KV blocks are drawn from.
+    """
+
+    def __init__(self, block_manager: "BlockManager") -> None:
+        self.blocks = block_manager
+        self._tables: dict[str, list[int]] = {}
+
+    def allocate(self, session_id: str, num_blocks: int) -> list[int]:
+        r"""Allocate ``num_blocks`` KV blocks for ``session_id``."""
+        ids = self.blocks.allocate(num_blocks)
+        self._tables[session_id] = list(ids)
+        return ids
+
+    def append(self, session_id: str, num_blocks: int = 1) -> list[int]:
+        r"""Grow a session's KV table by ``num_blocks`` (one decode chunk)."""
+        if session_id not in self._tables:
+            raise KeyError(f"no KV table for session {session_id!r}")
+        ids = self.blocks.allocate(num_blocks)
+        self._tables[session_id].extend(ids)
+        return ids
+
+    def block_table(self, session_id: str) -> list[int]:
+        r"""Return the ordered block ids backing a session's KV cache."""
+        return list(self._tables.get(session_id, []))
+
+    def fork(self, src_session_id: str, dst_session_id: str) -> list[int]:
+        r"""Copy-on-write fork: ``dst`` shares ``src``'s blocks until it writes."""
+        if src_session_id not in self._tables:
+            raise KeyError(f"no KV table for session {src_session_id!r}")
+        shared = self.blocks.share(self._tables[src_session_id])
+        self._tables[dst_session_id] = shared
+        return shared
+
+    def free(self, session_id: str) -> None:
+        r"""Release a session's KV blocks."""
+        table = self._tables.pop(session_id, None)
+        if table:
+            self.blocks.free(table)

--- a/worldkernels/runtime/memory/latent_pool.py
+++ b/worldkernels/runtime/memory/latent_pool.py
@@ -1,0 +1,57 @@
+r"""Pre-allocated tensor buffer pool.
+
+Hot-path code (the denoise loop, frame buffers) must never call
+``torch.zeros`` / ``torch.empty``. The pool hands out reusable buffers keyed by
+``(shape, dtype)`` and reclaims them on release.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ["LatentPool"]
+
+
+class LatentPool:
+    r"""Buffer pool that recycles tensors by shape and dtype.
+
+    Args:
+        device: Device buffers are allocated on.
+    """
+
+    def __init__(self, device: str) -> None:
+        self.device = device
+        self._free: dict[tuple, list[torch.Tensor]] = {}
+        self._in_use = 0
+
+    @property
+    def num_in_use(self) -> int:
+        return self._in_use
+
+    @property
+    def num_pooled(self) -> int:
+        return sum(len(bufs) for bufs in self._free.values())
+
+    def acquire(self, shape: "Sequence[int]", dtype: torch.dtype) -> torch.Tensor:
+        r"""Return a buffer of ``(shape, dtype)``, reusing a pooled one if available."""
+        key = (tuple(shape), dtype)
+        pool = self._free.get(key)
+        self._in_use += 1
+        if pool:
+            return pool.pop()
+        return torch.empty(tuple(shape), device=self.device, dtype=dtype)
+
+    def release(self, tensor: torch.Tensor) -> None:
+        r"""Return ``tensor`` to the pool for reuse."""
+        key = (tuple(tensor.shape), tensor.dtype)
+        self._free.setdefault(key, []).append(tensor)
+        self._in_use = max(0, self._in_use - 1)
+
+    def clear(self) -> None:
+        r"""Drop all pooled buffers."""
+        self._free.clear()

--- a/worldkernels/runtime/memory/offload.py
+++ b/worldkernels/runtime/memory/offload.py
@@ -1,0 +1,67 @@
+r"""Three-tier session-state offloading.
+
+Paused or cold session state can spill from VRAM to pinned host memory and,
+later, to NVMe. Host transfers use pinned buffers and a dedicated copy stream
+so they overlap compute. The NVMe tier is the declared seam; host transfers
+are implemented.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+
+import torch
+
+__all__ = ["MemoryTier", "Offloader"]
+
+
+class MemoryTier(str, Enum):
+    r"""Where session state currently resides."""
+
+    GPU = "gpu"
+    HOST = "host"
+    NVME = "nvme"
+
+
+class Offloader:
+    r"""Moves tensors between VRAM and pinned host memory.
+
+    Args:
+        device: The GPU device tensors are restored to.
+    """
+
+    def __init__(self, device: str) -> None:
+        self.device = device
+        self._pinning = device.startswith("cuda") and torch.cuda.is_available()
+        self._stream = torch.cuda.Stream() if self._pinning else None
+
+    @staticmethod
+    def tier_of(tensor: torch.Tensor) -> MemoryTier:
+        return MemoryTier.GPU if tensor.device.type == "cuda" else MemoryTier.HOST
+
+    def to_host(self, tensor: torch.Tensor) -> torch.Tensor:
+        r"""Copy ``tensor`` to (pinned) host memory."""
+        if tensor.device.type != "cuda":
+            return tensor
+        host = torch.empty(tensor.shape, dtype=tensor.dtype, device="cpu", pin_memory=self._pinning)
+        if self._stream is not None:
+            with torch.cuda.stream(self._stream):
+                host.copy_(tensor, non_blocking=True)
+            self._stream.synchronize()
+        else:
+            host.copy_(tensor)
+        return host
+
+    def to_device(self, tensor: torch.Tensor) -> torch.Tensor:
+        r"""Restore ``tensor`` to the GPU device."""
+        if tensor.device.type == "cuda":
+            return tensor
+        return tensor.to(self.device, non_blocking=self._pinning)
+
+    def offload(self, tensor: torch.Tensor, tier: MemoryTier) -> torch.Tensor:
+        r"""Move ``tensor`` to ``tier``."""
+        if tier is MemoryTier.GPU:
+            return self.to_device(tensor)
+        if tier is MemoryTier.HOST:
+            return self.to_host(tensor)
+        raise NotImplementedError("NVMe offload tier is not implemented yet")

--- a/worldkernels/runtime/memory/trajectory_cache.py
+++ b/worldkernels/runtime/memory/trajectory_cache.py
@@ -1,0 +1,84 @@
+r"""Trajectory prefix cache.
+
+A radix tree (trie) keyed by action-history hashes. Two sessions that issue
+the same sequence of actions from the same initial state produce the same
+latents; the cache lets the second session reuse the first's latent blocks for
+the shared prefix instead of recomputing them.
+
+Block ids stored at each node reference blocks in a
+`BlockManager`; this module
+holds only the index, not tensors, so it is torch-free.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+__all__ = ["TrajectoryCache"]
+
+
+@dataclass
+class _TrieNode:
+    block_ids: list[int] = field(default_factory=list)
+    children: dict[str, "_TrieNode"] = field(default_factory=dict)
+
+
+@dataclass
+class PrefixMatch:
+    r"""Result of a trajectory-prefix lookup.
+
+    Args:
+        length: Number of leading actions matched.
+        block_ids: Cached latent block ids for the matched prefix.
+    """
+
+    length: int
+    block_ids: list[int]
+
+
+class TrajectoryCache:
+    r"""Radix-tree cache mapping action-history prefixes to latent block ids."""
+
+    def __init__(self) -> None:
+        self._root = _TrieNode()
+        self._size = 0
+
+    @property
+    def size(self) -> int:
+        r"""Number of cached trajectory steps."""
+        return self._size
+
+    def insert(self, action_hashes: list[str], block_ids: list[int]) -> None:
+        r"""Cache the per-step latent block id for an action sequence.
+
+        Args:
+            action_hashes: Content hashes of each action in order.
+            block_ids: Latent block id produced after each action; same length.
+        """
+        if len(action_hashes) != len(block_ids):
+            raise ValueError("action_hashes and block_ids must have equal length")
+        node = self._root
+        for action_hash, block_id in zip(action_hashes, block_ids):
+            child = node.children.get(action_hash)
+            if child is None:
+                child = _TrieNode()
+                node.children[action_hash] = child
+                self._size += 1
+            child.block_ids = [block_id]
+            node = child
+
+    def match(self, action_hashes: list[str]) -> PrefixMatch:
+        r"""Return the longest cached prefix of ``action_hashes``."""
+        node = self._root
+        matched: list[int] = []
+        for action_hash in action_hashes:
+            child = node.children.get(action_hash)
+            if child is None or not child.block_ids:
+                break
+            matched.append(child.block_ids[0])
+            node = child
+        return PrefixMatch(length=len(matched), block_ids=matched)
+
+    def clear(self) -> None:
+        self._root = _TrieNode()
+        self._size = 0

--- a/worldkernels/runtime/metrics.py
+++ b/worldkernels/runtime/metrics.py
@@ -1,10 +1,97 @@
-"""Prometheus-style metrics for WorldKernels.
+r"""Prometheus metrics for the serving runtime.
 
-Stub module. Will expose:
-  - wk_step_latency_seconds (histogram)
-  - wk_active_sessions (gauge)
-  - wk_vram_usage_bytes (gauge)
-  - wk_frames_generated_total (counter)
-  - wk_cache_hit_ratio (gauge)
-  - wk_batch_size (histogram)
+Metrics live in a private `CollectorRegistry` so they never collide with
+a host application's default registry. The serving layer exposes them at
+``/metrics`` via `render()`.
 """
+
+from __future__ import annotations
+
+from prometheus_client import (
+    CONTENT_TYPE_LATEST,
+    CollectorRegistry,
+    Counter,
+    Gauge,
+    Histogram,
+    generate_latest as _generate_latest,
+)
+
+__all__ = [
+    "REGISTRY",
+    "CONTENT_TYPE_LATEST",
+    "render",
+    "observe_step",
+    "observe_batch",
+    "set_active_sessions",
+    "set_vram_bytes",
+    "set_cache_hit_ratio",
+]
+
+REGISTRY = CollectorRegistry()
+
+_STEP_LATENCY = Histogram(
+    "wk_step_latency_seconds",
+    "Wall-clock latency of one simulation step.",
+    registry=REGISTRY,
+)
+_FRAMES_TOTAL = Counter(
+    "wk_frames_generated_total",
+    "Total frames generated across all sessions.",
+    registry=REGISTRY,
+)
+_STEPS_TOTAL = Counter(
+    "wk_steps_total",
+    "Total simulation steps executed.",
+    registry=REGISTRY,
+)
+_BATCH_SIZE = Histogram(
+    "wk_batch_size",
+    "Number of sessions per batched forward pass.",
+    buckets=(1, 2, 4, 8, 16, 32),
+    registry=REGISTRY,
+)
+_ACTIVE_SESSIONS = Gauge(
+    "wk_active_sessions",
+    "Number of live sessions.",
+    registry=REGISTRY,
+)
+_VRAM_BYTES = Gauge(
+    "wk_vram_usage_bytes",
+    "Device memory currently allocated.",
+    registry=REGISTRY,
+)
+_CACHE_HIT_RATIO = Gauge(
+    "wk_cache_hit_ratio",
+    "Denoise-step cache hit ratio in [0, 1].",
+    registry=REGISTRY,
+)
+
+
+def observe_step(latency_seconds: float, frames: int = 0) -> None:
+    r"""Record one completed simulation step."""
+    _STEP_LATENCY.observe(latency_seconds)
+    _STEPS_TOTAL.inc()
+    if frames:
+        _FRAMES_TOTAL.inc(frames)
+
+
+def observe_batch(size: int) -> None:
+    r"""Record the size of one batched forward pass."""
+    _BATCH_SIZE.observe(size)
+
+
+def set_active_sessions(count: int) -> None:
+    _ACTIVE_SESSIONS.set(count)
+
+
+def set_vram_bytes(value: float) -> None:
+    _VRAM_BYTES.set(value)
+
+
+def set_cache_hit_ratio(ratio: float) -> None:
+    _CACHE_HIT_RATIO.set(ratio)
+
+
+def render() -> bytes:
+    r"""Render the metrics registry in Prometheus text exposition format."""
+    return _generate_latest(REGISTRY)

--- a/worldkernels/runtime/quantization.py
+++ b/worldkernels/runtime/quantization.py
@@ -1,8 +1,0 @@
-"""Quantization registry.
-
-Auto-detects the best precision for the current GPU and provides
-quantization methods (fp16, bf16, int8, int4) for model weights.
-
-Stub module. Implementation will wrap torch.ao, bitsandbytes,
-and GPTQ/AWQ backends.
-"""

--- a/worldkernels/runtime/quantization/__init__.py
+++ b/worldkernels/runtime/quantization/__init__.py
@@ -1,0 +1,10 @@
+r"""Weight quantization registry and schemes."""
+
+from __future__ import annotations
+
+from worldkernels.runtime.quantization.registry import (
+    QuantizationRegistry,
+    QuantizationScheme,
+)
+
+__all__ = ["QuantizationRegistry", "QuantizationScheme"]

--- a/worldkernels/runtime/quantization/registry.py
+++ b/worldkernels/runtime/quantization/registry.py
@@ -1,0 +1,70 @@
+r"""Quantization registry.
+
+Maps a `QuantizationScheme` to an applier that quantizes a module's
+weights in place. ``none`` is identity; ``int8`` / ``int4`` weight-only
+quantization is delegated to ``torchao`` and fails with an actionable install
+message when that optional dependency is absent.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import TYPE_CHECKING, Callable
+
+from worldkernels.utils import optional_import
+
+if TYPE_CHECKING:
+    import torch.nn as nn
+
+__all__ = ["QuantizationScheme", "QuantizationRegistry"]
+
+
+class QuantizationScheme(str, Enum):
+    r"""Supported weight-quantization schemes."""
+
+    NONE = "none"
+    INT8 = "int8"
+    INT4 = "int4"
+
+
+def _apply_none(module: "nn.Module") -> "nn.Module":
+    return module
+
+
+def _apply_int8(module: "nn.Module") -> "nn.Module":
+    ao = optional_import("torchao", "quant")
+    ao.quantization.quantize_(module, ao.quantization.int8_weight_only())
+    return module
+
+
+def _apply_int4(module: "nn.Module") -> "nn.Module":
+    ao = optional_import("torchao", "quant")
+    ao.quantization.quantize_(module, ao.quantization.int4_weight_only())
+    return module
+
+
+class QuantizationRegistry:
+    r"""Resolves a quantization scheme to its weight applier."""
+
+    def __init__(self) -> None:
+        self._appliers: dict[QuantizationScheme, Callable[["nn.Module"], "nn.Module"]] = {
+            QuantizationScheme.NONE: _apply_none,
+            QuantizationScheme.INT8: _apply_int8,
+            QuantizationScheme.INT4: _apply_int4,
+        }
+
+    def register(
+        self,
+        scheme: QuantizationScheme,
+        applier: Callable[["nn.Module"], "nn.Module"],
+    ) -> None:
+        r"""Register or override the applier for ``scheme``."""
+        self._appliers[scheme] = applier
+
+    def apply(self, module: "nn.Module", scheme: QuantizationScheme | str) -> "nn.Module":
+        r"""Quantize ``module`` in place under ``scheme`` and return it."""
+        scheme = QuantizationScheme(scheme)
+        applier = self._appliers.get(scheme)
+        if applier is None:
+            raise ValueError(f"no applier registered for scheme {scheme.value!r}")
+        return applier(module)

--- a/worldkernels/scheduler/__init__.py
+++ b/worldkernels/scheduler/__init__.py
@@ -1,0 +1,28 @@
+r"""Scheduler layer: continuous-batching dispatch, admission, preemption."""
+
+from __future__ import annotations
+
+from worldkernels.scheduler.admission import AdmissionController, AdmissionDecision
+from worldkernels.scheduler.batching import (
+    CompatibilityGroup,
+    CompatibilityKey,
+    group_requests,
+)
+from worldkernels.scheduler.preemption import (
+    PreemptionCandidate,
+    PreemptionDecision,
+    PreemptionPolicy,
+)
+from worldkernels.scheduler.scheduler import Scheduler
+
+__all__ = [
+    "Scheduler",
+    "CompatibilityKey",
+    "CompatibilityGroup",
+    "group_requests",
+    "AdmissionController",
+    "AdmissionDecision",
+    "PreemptionPolicy",
+    "PreemptionCandidate",
+    "PreemptionDecision",
+]

--- a/worldkernels/scheduler/admission.py
+++ b/worldkernels/scheduler/admission.py
@@ -1,0 +1,86 @@
+r"""Admission control.
+
+Before a session is created the admission controller checks that its profiled
+VRAM cost, plus a headroom margin, fits in free device memory and that the
+concurrent-session cap is not exceeded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from worldkernels.config import SchedulerConfig, WorldConfig
+    from worldkernels.worlds.base import WorldModel
+
+__all__ = ["AdmissionDecision", "AdmissionController"]
+
+
+@dataclass
+class AdmissionDecision:
+    r"""Outcome of an admission check.
+
+    Args:
+        admitted: Whether the session may be created.
+        reason: Human-readable explanation when refused.
+        required_mb: Profiled VRAM the session needs.
+        available_mb: Free device VRAM at decision time.
+    """
+
+    admitted: bool
+    reason: str = ""
+    required_mb: float = 0.0
+    available_mb: float = 0.0
+
+
+class AdmissionController:
+    r"""Gates session creation on VRAM headroom and the concurrency cap.
+
+    Args:
+        config: Scheduler policy (concurrency cap, headroom margin).
+    """
+
+    def __init__(self, config: "SchedulerConfig") -> None:
+        self.config = config
+
+    def check(
+        self,
+        world: "WorldModel",
+        world_config: "WorldConfig",
+        *,
+        live_sessions: int,
+        free_vram_mb: float | None,
+    ) -> AdmissionDecision:
+        r"""Decide whether a new session for ``world`` may be admitted.
+
+        Args:
+            world: The world model the session will run.
+            world_config: Per-session generation parameters.
+            live_sessions: Current number of live sessions.
+            free_vram_mb: Free device VRAM, or ``None`` on CPU (skips the check).
+        """
+        if live_sessions >= self.config.max_concurrent_sessions:
+            return AdmissionDecision(
+                admitted=False,
+                reason=(
+                    f"concurrency cap reached "
+                    f"({live_sessions}/{self.config.max_concurrent_sessions})"
+                ),
+            )
+        required = world.profile_vram(world_config)
+        if free_vram_mb is None:
+            return AdmissionDecision(admitted=True, required_mb=required)
+        budget = free_vram_mb - self.config.admission_headroom_mb
+        if required > budget:
+            return AdmissionDecision(
+                admitted=False,
+                reason=(
+                    f"insufficient VRAM: need {required:.0f} MB + "
+                    f"{self.config.admission_headroom_mb:.0f} MB headroom, "
+                    f"{free_vram_mb:.0f} MB free"
+                ),
+                required_mb=required,
+                available_mb=free_vram_mb,
+            )
+        return AdmissionDecision(admitted=True, required_mb=required, available_mb=free_vram_mb)

--- a/worldkernels/scheduler/batching.py
+++ b/worldkernels/scheduler/batching.py
@@ -1,0 +1,69 @@
+r"""Compatibility-group batching.
+
+Two step requests may share a batched forward pass only if they run the same
+world model in the same regime. `CompatibilityKey` is the equivalence
+class; `group_requests()` partitions a queue into batchable groups, each
+capped at the scheduler's ``max_batch_size``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from worldkernels.core.request import StepRequest
+
+__all__ = ["CompatibilityKey", "CompatibilityGroup", "group_requests"]
+
+
+@dataclass(frozen=True)
+class CompatibilityKey:
+    r"""Equivalence class for batching: same world instance, same regime."""
+
+    world_id: int
+    transition_mode: str
+    decode: bool
+
+    @classmethod
+    def of(cls, request: "StepRequest") -> "CompatibilityKey":
+        return cls(
+            world_id=id(request.world),
+            transition_mode=request.world.transition_mode.value,
+            decode=request.decode,
+        )
+
+
+@dataclass
+class CompatibilityGroup:
+    r"""A set of step requests that can share one batched forward pass."""
+
+    key: CompatibilityKey
+    requests: list["StepRequest"]
+
+    @property
+    def size(self) -> int:
+        return len(self.requests)
+
+
+def group_requests(
+    requests: list["StepRequest"],
+    *,
+    max_batch_size: int,
+) -> list[CompatibilityGroup]:
+    r"""Partition ``requests`` into compatibility groups capped at ``max_batch_size``.
+
+    Insertion order is preserved within each group; a group that exceeds the
+    cap is split into consecutive batches.
+    """
+    if max_batch_size < 1:
+        raise ValueError(f"max_batch_size must be >= 1, got {max_batch_size}")
+    by_key: dict[CompatibilityKey, list[StepRequest]] = {}
+    for request in requests:
+        by_key.setdefault(CompatibilityKey.of(request), []).append(request)
+
+    groups: list[CompatibilityGroup] = []
+    for key, members in by_key.items():
+        for start in range(0, len(members), max_batch_size):
+            groups.append(CompatibilityGroup(key, members[start : start + max_batch_size]))
+    return groups

--- a/worldkernels/scheduler/preemption.py
+++ b/worldkernels/scheduler/preemption.py
@@ -1,0 +1,64 @@
+r"""Preemption policy.
+
+Under VRAM pressure the scheduler reclaims a running session's state. Two
+mechanisms: *swap* (copy state to host memory, restore later) and *recompute*
+(drop state, replay the action sequence from a checkpoint). The policy picks a
+victim and the mechanism.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+__all__ = ["PreemptionCandidate", "PreemptionDecision", "PreemptionPolicy"]
+
+
+@dataclass
+class PreemptionCandidate:
+    r"""A running session considered for preemption.
+
+    Args:
+        session_id: The session.
+        last_active_step: Monotonic step index of its last activity.
+        priority: Higher means more important; preempt low-priority first.
+        state_bytes: Footprint of its latent state.
+    """
+
+    session_id: str
+    last_active_step: int
+    priority: int = 0
+    state_bytes: int = 0
+
+
+@dataclass
+class PreemptionDecision:
+    victim_id: str
+    mode: Literal["swap", "recompute"]
+
+
+class PreemptionPolicy:
+    r"""Selects which session to preempt and how.
+
+    Args:
+        mode: Preferred reclamation mechanism.
+    """
+
+    def __init__(self, mode: Literal["swap", "recompute"] = "swap") -> None:
+        self.mode = mode
+
+    def select_victim(
+        self,
+        candidates: "Sequence[PreemptionCandidate]",
+    ) -> PreemptionDecision | None:
+        r"""Pick the lowest-priority, least-recently-active session to preempt.
+
+        Returns ``None`` when there is nothing to preempt.
+        """
+        if not candidates:
+            return None
+        victim = min(candidates, key=lambda c: (c.priority, c.last_active_step))
+        return PreemptionDecision(victim_id=victim.session_id, mode=self.mode)

--- a/worldkernels/scheduler/scheduler.py
+++ b/worldkernels/scheduler/scheduler.py
@@ -1,0 +1,106 @@
+r"""Scheduler — continuous-batching dispatch layer.
+
+Owns the transient `StepRequest` queue and
+dispatches work to a `Worker`. It does *not*
+own sessions — the engine's session registry does.
+
+Two entry points:
+
+- `step()` — synchronous, used by ``Session.step`` today: dispatch one
+  request and return its result.
+- `add_request()` / `run_scheduled()` — the queue path: many requests
+  are enqueued, partitioned into `CompatibilityGroup` batches, and each
+  group dispatched as one batched forward. The async engine drives this.
+
+Admission and preemption policy live here as `admission` and
+`preemption` for the engine to consult.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from worldkernels.config import SchedulerConfig
+from worldkernels.scheduler.admission import AdmissionController
+from worldkernels.scheduler.batching import CompatibilityGroup, group_requests
+from worldkernels.scheduler.preemption import PreemptionPolicy
+
+if TYPE_CHECKING:
+    from worldkernels.core.action import Action
+    from worldkernels.core.observation import Observation
+    from worldkernels.core.request import StepRequest
+    from worldkernels.core.session import LatentState
+    from worldkernels.worker.worker import Worker
+    from worldkernels.worlds.base import WorldModel
+
+__all__ = ["Scheduler"]
+
+
+class Scheduler:
+    r"""Dispatches step requests to a worker, batching compatible ones.
+
+    Args:
+        worker: The worker that executes requests.
+        config: Batching / admission / preemption policy.
+    """
+
+    def __init__(self, worker: "Worker", config: SchedulerConfig | None = None) -> None:
+        self.worker = worker
+        self.config = config or SchedulerConfig()
+        self.admission = AdmissionController(self.config)
+        self.preemption = PreemptionPolicy(self.config.preemption_mode)
+        self._queue: list[StepRequest] = []
+
+    @property
+    def pending(self) -> int:
+        r"""Number of requests waiting in the queue."""
+        return len(self._queue)
+
+    def step(
+        self,
+        *,
+        world: "WorldModel",
+        state: "LatentState",
+        action: "Action",
+        modalities: list[str],
+        step_index: int,
+        decode: bool = True,
+    ) -> tuple["LatentState", "Observation"]:
+        r"""Dispatch one simulation step synchronously and return its result."""
+        from worldkernels.core.request import StepRequest
+
+        request = StepRequest(
+            session_id="",
+            world=world,
+            state=state,
+            action=action,
+            modalities=list(modalities),
+            step_index=step_index,
+            decode=decode,
+        )
+        (result,) = self.worker.execute([request])
+        return result
+
+    def add_request(self, request: "StepRequest") -> None:
+        r"""Enqueue a step request for the next scheduling round."""
+        self._queue.append(request)
+
+    def schedule(self) -> list[CompatibilityGroup]:
+        r"""Drain the queue into compatibility-group batches."""
+        if not self._queue:
+            return []
+        groups = group_requests(self._queue, max_batch_size=self.config.max_batch_size)
+        self._queue.clear()
+        return groups
+
+    def run_scheduled(self) -> dict[str, tuple["LatentState", "Observation"]]:
+        r"""Schedule pending requests, dispatch each group batched, and collect results.
+
+        Returns a mapping from ``session_id`` to ``(new_state, observation)``.
+        """
+        results: dict[str, tuple[LatentState, Observation]] = {}
+        for group in self.schedule():
+            outputs = self.worker.execute(group.requests)
+            for request, output in zip(group.requests, outputs):
+                results[request.session_id] = output
+        return results

--- a/worldkernels/serving/routes.py
+++ b/worldkernels/serving/routes.py
@@ -1,18 +1,23 @@
-r"""REST API routes for WorldKernels serving layer."""
+r"""REST API routes for the WorldKernels serving layer.
+
+Routes are bound to an `AsyncEngine`: model loading, session creation,
+and stepping go through its async, continuous-batching API; cheap registry
+reads touch the underlying `WorldEngine` directly.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import base64
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException
 from pydantic import BaseModel, Field
 
-from worldkernels.core.config import WorldConfig
-from worldkernels.core.engine import WorldKernel
+from worldkernels.config import WorldConfig
 from worldkernels.core.errors import (
     SessionLimitError,
+    SessionNotFoundError,
+    SessionPausedError,
     SessionTerminatedError,
     VRAMExhaustedError,
     WorldAlreadyLoadedError,
@@ -20,32 +25,27 @@ from worldkernels.core.errors import (
     WorldKernelError,
     WorldNotFoundError,
 )
+from worldkernels.serving.websocket import register_websocket_routes
+
+if TYPE_CHECKING:
+    from worldkernels.engine.async_engine import AsyncEngine
 
 router = APIRouter(prefix="/v1")
 
 
-def _engine() -> WorldKernel:
-    raise RuntimeError("Engine dependency not configured.")
+def configure_routes(async_engine: "AsyncEngine", auth_dep: Any = None) -> APIRouter:
+    r"""Bind an `AsyncEngine` and optional auth to the router."""
+    engine = async_engine.engine
+    deps = [Depends(auth_dep)] if auth_dep is not None else []
 
-
-def configure_routes(engine: WorldKernel, auth_dep: Any = None) -> APIRouter:
-    r"""Bind the engine instance and optional auth to the router."""
-
-    deps = [Depends(lambda: engine)]
-    if auth_dep is not None:
-        deps.append(Depends(auth_dep))
-
-    router.dependency_overrides_provider = None  # type: ignore[attr-defined]
-
-    @router.get("/worlds", tags=["worlds"])
+    @router.get("/worlds", tags=["worlds"], dependencies=deps)
     async def list_worlds() -> dict[str, Any]:
         return {"worlds": engine.list_worlds()}
 
-    @router.post("/worlds", tags=["worlds"], status_code=201)
+    @router.post("/worlds", tags=["worlds"], status_code=201, dependencies=deps)
     async def load_model(req: LoadModelRequest) -> dict[str, str]:
         try:
-            await asyncio.to_thread(
-                engine.load_model,
+            await async_engine.load_model(
                 req.model_id,
                 alias=req.alias,
                 trust_remote_code=req.trust_remote_code,
@@ -57,27 +57,26 @@ def configure_routes(engine: WorldKernel, auth_dep: Any = None) -> APIRouter:
             raise HTTPException(status_code=404, detail=str(exc))
         except WorldInitError as exc:
             raise HTTPException(status_code=500, detail=str(exc))
-        key = req.alias or req.model_id.split("/")[-1]
-        return {"status": "loaded", "world": key}
+        return {"status": "loaded", "world": req.alias or req.model_id.split("/")[-1]}
 
-    @router.delete("/worlds/{world_id}", tags=["worlds"])
+    @router.delete("/worlds/{world_id}", tags=["worlds"], dependencies=deps)
     async def unload_model(world_id: str) -> dict[str, str]:
         try:
-            engine.unload_model(world_id)
+            await async_engine.unload_model(world_id)
         except WorldNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc))
         return {"status": "unloaded", "world": world_id}
 
-    @router.get("/sessions", tags=["sessions"])
+    @router.get("/sessions", tags=["sessions"], dependencies=deps)
     async def list_sessions() -> dict[str, Any]:
-        sessions = []
-        for sid in engine.list_sessions():
-            sess = engine.get_session(sid)
-            if sess is not None:
-                sessions.append(_session_summary(sess))
-        return {"sessions": sessions}
+        summaries = [
+            _session_summary(engine.get_session(sid))
+            for sid in engine.list_sessions()
+            if engine.get_session(sid) is not None
+        ]
+        return {"sessions": summaries}
 
-    @router.post("/sessions", tags=["sessions"], status_code=201)
+    @router.post("/sessions", tags=["sessions"], status_code=201, dependencies=deps)
     async def create_session(req: CreateSessionRequest) -> dict[str, Any]:
         config = WorldConfig(
             height=req.height,
@@ -89,9 +88,7 @@ def configure_routes(engine: WorldKernel, auth_dep: Any = None) -> APIRouter:
             initial_prompt=req.initial_prompt,
         )
         try:
-            sess = await asyncio.to_thread(
-                engine.create_session, req.world, config=config, seed=req.seed
-            )
+            sess = await async_engine.create_session(req.world, config=config, seed=req.seed)
         except WorldNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc))
         except SessionLimitError as exc:
@@ -100,71 +97,63 @@ def configure_routes(engine: WorldKernel, auth_dep: Any = None) -> APIRouter:
             raise HTTPException(status_code=507, detail=str(exc))
         return _session_summary(sess)
 
-    @router.get("/sessions/{session_id}", tags=["sessions"])
+    @router.get("/sessions/{session_id}", tags=["sessions"], dependencies=deps)
     async def get_session(session_id: str) -> dict[str, Any]:
-        sess = engine.get_session(session_id)
-        if sess is None:
-            raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found.")
-        return _session_summary(sess)
+        return _session_summary(_require_session(engine, session_id))
 
-    @router.delete("/sessions/{session_id}", tags=["sessions"])
+    @router.delete("/sessions/{session_id}", tags=["sessions"], dependencies=deps)
     async def delete_session(session_id: str) -> dict[str, str]:
-        sess = engine.get_session(session_id)
-        if sess is None:
-            raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found.")
-        engine.close_session(session_id)
+        _require_session(engine, session_id)
+        await async_engine.close_session(session_id)
         return {"status": "terminated", "session_id": session_id}
 
-    @router.post("/sessions/{session_id}/step", tags=["sessions"])
+    @router.post("/sessions/{session_id}/step", tags=["sessions"], dependencies=deps)
     async def step(session_id: str, req: StepRequest) -> dict[str, Any]:
         from worldkernels.core.action import Action
 
-        sess = engine.get_session(session_id)
-        if sess is None:
-            raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found.")
         action = Action(action_type=req.action_type, payload=req.payload)
         try:
-            obs = await asyncio.to_thread(
-                sess.step, action, modalities=req.modalities, decode=req.decode
+            obs = await async_engine.step(
+                session_id, action, modalities=req.modalities, decode=req.decode
             )
-        except SessionTerminatedError as exc:
+        except SessionNotFoundError as exc:
+            raise HTTPException(status_code=404, detail=str(exc))
+        except (SessionTerminatedError, SessionPausedError) as exc:
             raise HTTPException(status_code=410, detail=str(exc))
+        except RuntimeError as exc:
+            raise HTTPException(status_code=409, detail=str(exc))
         except WorldKernelError as exc:
             raise HTTPException(status_code=500, detail=str(exc))
-        return _observation_to_dict(obs, session_id, sess.step_index)
+        return _observation_to_dict(obs, session_id)
 
-    @router.post("/sessions/{session_id}/checkpoint", tags=["sessions"])
+    @router.post("/sessions/{session_id}/checkpoint", tags=["sessions"], dependencies=deps)
     async def checkpoint(session_id: str) -> dict[str, str]:
-        sess = engine.get_session(session_id)
-        if sess is None:
-            raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found.")
-        ckpt_id = sess.checkpoint()
-        return {"checkpoint_id": ckpt_id, "session_id": session_id}
+        sess = _require_session(engine, session_id)
+        return {"checkpoint_id": sess.checkpoint(), "session_id": session_id}
 
-    @router.post("/sessions/{session_id}/restore", tags=["sessions"])
+    @router.post("/sessions/{session_id}/restore", tags=["sessions"], dependencies=deps)
     async def restore(session_id: str, req: RestoreRequest) -> dict[str, str]:
-        sess = engine.get_session(session_id)
-        if sess is None:
-            raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found.")
+        sess = _require_session(engine, session_id)
         try:
             sess.restore(req.checkpoint_id)
         except WorldKernelError as exc:
             raise HTTPException(status_code=404, detail=str(exc))
         return {"status": "restored", "checkpoint_id": req.checkpoint_id}
 
-    @router.post("/sessions/{session_id}/branch", tags=["sessions"], status_code=201)
+    @router.post(
+        "/sessions/{session_id}/branch", tags=["sessions"], status_code=201, dependencies=deps
+    )
     async def branch(session_id: str) -> dict[str, Any]:
-        sess = engine.get_session(session_id)
-        if sess is None:
-            raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found.")
+        sess = _require_session(engine, session_id)
         branched = sess.branch()
         engine._sessions[branched.session_id] = branched
         return _session_summary(branched)
 
+    register_websocket_routes(router, async_engine)
     return router
 
 
-# ---- request / response models -------------------------------------------
+# ---- request models ------------------------------------------------------
 
 
 class LoadModelRequest(BaseModel):
@@ -200,6 +189,13 @@ class RestoreRequest(BaseModel):
 # ---- helpers --------------------------------------------------------------
 
 
+def _require_session(engine: Any, session_id: str) -> Any:
+    sess = engine.get_session(session_id)
+    if sess is None:
+        raise HTTPException(status_code=404, detail=f"Session '{session_id}' not found.")
+    return sess
+
+
 def _session_summary(sess: Any) -> dict[str, Any]:
     return {
         "session_id": sess.session_id,
@@ -212,7 +208,7 @@ def _session_summary(sess: Any) -> dict[str, Any]:
     }
 
 
-def _observation_to_dict(obs: Any, session_id: str, step_index: int) -> dict[str, Any]:
+def _observation_to_dict(obs: Any, session_id: str) -> dict[str, Any]:
     result: dict[str, Any] = {
         "session_id": session_id,
         "step_index": obs.step_index,

--- a/worldkernels/serving/server.py
+++ b/worldkernels/serving/server.py
@@ -2,11 +2,11 @@ r"""FastAPI application factory for WorldKernels."""
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 
-from worldkernels.core.config import ServerConfig
-from worldkernels.core.engine import WorldKernel
+from worldkernels.config import ServerConfig
+from worldkernels.engine import AsyncEngine, WorldEngine
 from worldkernels.serving.auth import require_api_key
 from worldkernels.serving.routes import configure_routes
 
@@ -15,7 +15,7 @@ def create_app(
     server_config: ServerConfig | None = None,
     device: str = "cuda",
 ) -> FastAPI:
-    r"""Build the FastAPI application with engine and routes wired up."""
+    r"""Build the FastAPI application with engine, routes, and metrics wired up."""
     cfg = server_config or ServerConfig()
 
     app = FastAPI(
@@ -23,7 +23,6 @@ def create_app(
         description="GPU-first world model simulation engine",
         version="0.1.0",
     )
-
     app.add_middleware(
         CORSMiddleware,
         allow_origins=cfg.cors_origins,
@@ -31,22 +30,26 @@ def create_app(
         allow_headers=["*"],
     )
 
-    engine = WorldKernel(
-        device=device,
-        max_sessions=cfg.max_sessions,
-    )
+    engine = WorldEngine(device=device, max_sessions=cfg.max_sessions)
+    async_engine = AsyncEngine(engine)
     app.state.engine = engine
+    app.state.async_engine = async_engine
 
-    auth_dep = require_api_key(cfg.api_key)
-    router = configure_routes(engine, auth_dep=auth_dep)
+    router = configure_routes(async_engine, auth_dep=require_api_key(cfg.api_key))
     app.include_router(router)
 
     @app.get("/health")
     async def health() -> dict[str, str]:
         return {"status": "ok"}
 
+    @app.get("/metrics")
+    async def metrics() -> Response:
+        from worldkernels.runtime import metrics as wk_metrics
+
+        return Response(content=wk_metrics.render(), media_type=wk_metrics.CONTENT_TYPE_LATEST)
+
     @app.on_event("shutdown")
     async def _shutdown() -> None:
-        engine.shutdown()
+        await async_engine.shutdown()
 
     return app

--- a/worldkernels/serving/websocket.py
+++ b/worldkernels/serving/websocket.py
@@ -1,0 +1,69 @@
+r"""WebSocket frame streaming.
+
+A client opens ``/v1/sessions/{id}/stream``, then sends one JSON action per
+message and receives one JSON observation back. Long-lived sessions avoid the
+per-step HTTP handshake and let the engine pipeline steps.
+"""
+
+from __future__ import annotations
+
+import base64
+from typing import TYPE_CHECKING, Any
+
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
+if TYPE_CHECKING:
+    from worldkernels.engine.async_engine import AsyncEngine
+
+__all__ = ["register_websocket_routes"]
+
+
+def _observation_payload(obs: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "step_index": obs.step_index,
+        "generation_time_ms": obs.generation_time_ms,
+        "decode_skipped": obs.decode_skipped,
+    }
+    if obs.frames is not None:
+        payload["frames"] = [
+            base64.b64encode(f).decode("ascii") if isinstance(f, (bytes, bytearray)) else None
+            for f in obs.frames
+        ]
+    if obs.stage_timing is not None:
+        payload["stage_timing"] = obs.stage_timing.as_dict()
+    return payload
+
+
+def register_websocket_routes(router: APIRouter, async_engine: "AsyncEngine") -> None:
+    r"""Attach the session-streaming WebSocket route to ``router``."""
+
+    @router.websocket("/sessions/{session_id}/stream")
+    async def stream(websocket: WebSocket, session_id: str) -> None:
+        from worldkernels.core.action import Action
+        from worldkernels.core.errors import WorldKernelError
+
+        await websocket.accept()
+        if async_engine.engine.get_session(session_id) is None:
+            await websocket.send_json({"error": f"session {session_id!r} not found"})
+            await websocket.close()
+            return
+        try:
+            while True:
+                message = await websocket.receive_json()
+                action = Action(
+                    action_type=message.get("action_type", "null"),
+                    payload=message.get("payload", {}),
+                )
+                try:
+                    obs = await async_engine.step(
+                        session_id,
+                        action,
+                        modalities=message.get("modalities", ["frames"]),
+                        decode=message.get("decode", True),
+                    )
+                except WorldKernelError as exc:
+                    await websocket.send_json({"error": str(exc)})
+                    continue
+                await websocket.send_json(_observation_payload(obs))
+        except WebSocketDisconnect:
+            return

--- a/worldkernels/worker/__init__.py
+++ b/worldkernels/worker/__init__.py
@@ -1,0 +1,22 @@
+r"""Worker layer: device infrastructure and the compute runner."""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+__all__ = ["Worker", "WorldRunner"]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "Worker": ("worldkernels.worker.worker", "Worker"),
+    "WorldRunner": ("worldkernels.worker.world_runner", "WorldRunner"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/worker/worker.py
+++ b/worldkernels/worker/worker.py
@@ -1,0 +1,56 @@
+r"""Worker — the device-infrastructure layer.
+
+One worker owns one device: it binds the CUDA context, initializes the
+distributed parallel state, and holds a `WorldRunner`. The scheduler
+dispatches step requests to it. Multi-rank workers and out-of-process
+isolation are added by the distributed step of the restructure.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from worldkernels.worker.world_runner import WorldRunner
+
+if TYPE_CHECKING:
+    import torch
+
+    from worldkernels.config import ParallelConfig
+    from worldkernels.core.observation import Observation
+    from worldkernels.core.request import StepRequest
+    from worldkernels.core.session import LatentState
+
+__all__ = ["Worker"]
+
+
+class Worker:
+    r"""Owns one device and the runner that executes on it.
+
+    Args:
+        device: Target device string.
+        dtype: Compute dtype.
+        parallel_config: Parallelism degrees; single-rank by default.
+    """
+
+    def __init__(
+        self,
+        device: str,
+        dtype: "torch.dtype",
+        parallel_config: "ParallelConfig | None" = None,
+    ) -> None:
+        from worldkernels.config import ParallelConfig
+        from worldkernels.distributed import init_distributed, is_initialized
+
+        self.device = device
+        self.dtype = dtype
+        self.parallel_config = parallel_config or ParallelConfig()
+        if not is_initialized():
+            init_distributed(self.parallel_config)
+        self.runner = WorldRunner(device, dtype)
+
+    def execute(
+        self,
+        requests: list["StepRequest"],
+    ) -> list[tuple["LatentState", "Observation"]]:
+        r"""Run a batch of step requests on this worker's device."""
+        return self.runner.run_batch(requests)

--- a/worldkernels/worker/world_runner.py
+++ b/worldkernels/worker/world_runner.py
@@ -1,0 +1,44 @@
+r"""WorldRunner — the compute layer.
+
+Holds the executor and runs batched step requests under a
+`ForwardContext`. Equivalent to
+vLLM-Omni's ModelRunner: all model compute happens here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from worldkernels.runtime.executor import Executor
+from worldkernels.runtime.forward_context import ForwardContext, set_forward_context
+
+if TYPE_CHECKING:
+    import torch
+
+    from worldkernels.core.observation import Observation
+    from worldkernels.core.request import StepRequest
+    from worldkernels.core.session import LatentState
+
+__all__ = ["WorldRunner"]
+
+
+class WorldRunner:
+    r"""Runs world-model steps on one device.
+
+    Args:
+        device: Target device string.
+        dtype: Compute dtype.
+    """
+
+    def __init__(self, device: str, dtype: "torch.dtype") -> None:
+        self.device = device
+        self.dtype = dtype
+        self.executor = Executor(device=device, dtype=dtype)
+
+    def run_batch(
+        self,
+        requests: list["StepRequest"],
+    ) -> list[tuple["LatentState", "Observation"]]:
+        r"""Execute a batch of step requests under a forward context."""
+        with set_forward_context(ForwardContext()):
+            return self.executor.execute_batched(requests)


### PR DESCRIPTION
Reorganises worldkernels stack: engine -> scheduler -> worker -> worldrunner. Adds core/state.WorldState, paged-memory subsystem, distributed primitives (TP/SP/CFG), pluggable attention, regional torch.compile + CUDAGraphRunner, TeaCache step-skipping, weight-quantization registry, AsyncEngine continuous batching, websocket frame streaming, prometheus /metrics. Renames WorldKernel -> WorldEngine, AbstractWorld -> WorldModel, estimate_vram_mb -> profile_vram; hoists model substrate to top-level models/; deletes worlds/adapters/* , Wan and Cosmos-Predict2 surface via GeneratorWorld. 513 tests pass under pytest -m "not gpu"; ruff clean.

