### PR TITLE
[PR] auto-install deps + runtimeconfig switch panel + activate dormant subsystems

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ dependencies = [
     "imageio>=2.30",
     "nvidia-ml-py>=12.0",
     "prometheus_client>=0.17",
+    "uv>=0.5",
+    "msgpack>=1.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dependencies = [
     "numpy",
     "pydantic>=2.0",
     "tyro>=0.8",
+    "rich>=13.0",
     "fastapi>=0.100",
     "uvicorn[standard]>=0.20",
     "websockets>=11.0",

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -1,0 +1,16 @@
+# Pure-Python deps shared across all device targets.
+# Mirrors pyproject.toml [project] dependencies. Update both in lockstep.
+numpy
+pydantic>=2.0
+tyro>=0.8
+rich>=13.0
+fastapi>=0.100
+uvicorn[standard]>=0.20
+websockets>=11.0
+huggingface_hub>=0.20
+safetensors>=0.4
+einops>=0.7
+imageio>=2.30
+prometheus_client>=0.17
+uv>=0.5
+msgpack>=1.0

--- a/requirements/cpu.txt
+++ b/requirements/cpu.txt
@@ -1,0 +1,4 @@
+-r common.txt
+# CPU-only target. No flash-attn / xformers / NVIDIA tooling.
+# Install torch from https://download.pytorch.org/whl/cpu.
+torch>=2.0

--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -1,0 +1,8 @@
+-r common.txt
+# CUDA-target: torch built against CUDA, NVIDIA tooling, flash attention.
+torch>=2.0
+nvidia-ml-py>=12.0
+# CUDA-ABI-coupled (uncomment after pinning to your CUDA version):
+# flash-attn>=2.7
+# xformers>=0.0.27
+# triton>=2.3

--- a/requirements/rocm.txt
+++ b/requirements/rocm.txt
@@ -1,0 +1,4 @@
+-r common.txt
+# ROCm-target: torch+ROCm wheels, hipBLAS-coupled deps.
+# Install torch from https://download.pytorch.org/whl/rocm6.2 (or matching ROCm version).
+torch>=2.0

--- a/tests/cli/test_run.py
+++ b/tests/cli/test_run.py
@@ -10,17 +10,17 @@ from worldkernels.cli.run import _raw_to_arrays, _save_frames, _save_video, run_
 class TestRunSession:
     def test_invalid_output_format_raises(self):
         with pytest.raises(ValueError, match="output-format"):
-            run_session(world="dummy", output_format="bad", device="cpu")
+            run_session(model="dummy", output_format="bad", device="cpu")
 
     def test_default_run_no_output_dir(self, capsys):
-        run_session(world="dummy", steps=2, height=32, width=32, device="cpu")
+        run_session(model="dummy", steps=2, height=32, width=32, device="cpu")
         out = capsys.readouterr().out
         assert "Running 2 steps" in out
         assert "Done. 2 steps" in out
 
     def test_output_dir_saves_frames(self, tmp_path, capsys):
         run_session(
-            world="dummy",
+            model="dummy",
             steps=2,
             height=32,
             width=32,
@@ -34,7 +34,7 @@ class TestRunSession:
     def test_output_video_format(self, tmp_path):
         pytest.importorskip("imageio_ffmpeg")
         run_session(
-            world="dummy",
+            model="dummy",
             steps=2,
             height=32,
             width=32,
@@ -47,7 +47,7 @@ class TestRunSession:
     def test_output_both(self, tmp_path):
         pytest.importorskip("imageio_ffmpeg")
         run_session(
-            world="dummy",
+            model="dummy",
             steps=2,
             height=32,
             width=32,
@@ -60,7 +60,7 @@ class TestRunSession:
 
     def test_decode_false_skips_frames(self, tmp_path):
         run_session(
-            world="dummy",
+            model="dummy",
             steps=2,
             height=32,
             width=32,

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -32,7 +32,11 @@ class TestRunServe:
         monkeypatch.setattr("uvicorn.run", lambda *a, **kw: None)
         with patch("worldkernels.engine.WorldEngine.load_model") as load_mock:
             run_serve(
-                "0.0.0.0", 8000, 1, "k", "cpu",
+                "0.0.0.0",
+                8000,
+                1,
+                "k",
+                "cpu",
                 model="dummy",
                 model_kwargs={"num_inference_steps": 5, "guidance_scale": 3.0},
             )

--- a/tests/cli/test_serve.py
+++ b/tests/cli/test_serve.py
@@ -18,20 +18,25 @@ class TestRunServe:
         run_serve("0.0.0.0", 8000, 2, None, "cpu")
         assert captured == {"host": "0.0.0.0", "port": 8000}
 
-    def test_with_model_preloads(self, monkeypatch, capsys):
+    def test_with_model_preloads(self, monkeypatch):
         called = {}
         monkeypatch.setattr("uvicorn.run", lambda *a, **kw: called.setdefault("uvicorn", True))
 
         with patch("worldkernels.engine.WorldEngine.load_model") as load_mock:
-            run_serve("0.0.0.0", 8000, 2, None, "cpu", "dummy", {})
-            load_mock.assert_called_once_with("dummy")
-
-        out = capsys.readouterr().out
-        assert "Pre-loading model: dummy" in out
-        assert called["uvicorn"] is True
+            run_serve("0.0.0.0", 8000, 2, None, "cpu", model="dummy")
+            load_mock.assert_called_once()
+            assert load_mock.call_args.args == ("dummy",)
+            assert called["uvicorn"] is True
 
     def test_with_model_kwargs(self, monkeypatch):
         monkeypatch.setattr("uvicorn.run", lambda *a, **kw: None)
         with patch("worldkernels.engine.WorldEngine.load_model") as load_mock:
-            run_serve("0.0.0.0", 8000, 1, "k", "cpu", "dummy", {"variant": "v"})
-            load_mock.assert_called_once_with("dummy", variant="v")
+            run_serve(
+                "0.0.0.0", 8000, 1, "k", "cpu",
+                model="dummy",
+                model_kwargs={"num_inference_steps": 5, "guidance_scale": 3.0},
+            )
+            load_mock.assert_called_once()
+            assert load_mock.call_args.args == ("dummy",)
+            assert load_mock.call_args.kwargs.get("num_inference_steps") == 5
+            assert load_mock.call_args.kwargs.get("guidance_scale") == 3.0

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -1,0 +1,87 @@
+r"""Profile bundles + resolution precedence (default < profile < env < cli)."""
+
+from __future__ import annotations
+
+import pytest
+
+from worldkernels.config.profiles import PROFILES, profile_config, resolve_runtime_config
+
+
+class TestProfiles:
+    def test_baseline_turns_optimizations_off(self):
+        cfg = profile_config("baseline")
+        assert cfg.torch_compile is False
+        assert cfg.cuda_graphs is False
+        assert cfg.continuous_batching is False
+        assert cfg.teacache is False
+        assert cfg.attention_backend == "sdpa"
+
+    def test_default_profile_is_defaults(self):
+        cfg = profile_config("default")
+        assert cfg.torch_compile is True
+        assert cfg.continuous_batching is True
+
+    def test_production_enables_quant_and_teacache(self):
+        cfg = profile_config("production")
+        assert cfg.teacache is True
+        assert cfg.quantization == "int8"
+
+    def test_unknown_profile_raises(self):
+        with pytest.raises(ValueError, match="unknown profile"):
+            resolve_runtime_config(profile="nope")
+
+    def test_all_profiles_resolve(self):
+        for name in PROFILES:
+            cfg, sources = resolve_runtime_config(profile=name)
+            assert cfg is not None
+            assert isinstance(sources, dict)
+
+
+class TestPrecedence:
+    def test_sources_default(self):
+        _, sources = resolve_runtime_config(env={})
+        assert sources["torch_compile"] == "default"
+
+    def test_profile_source_attribution(self):
+        _, sources = resolve_runtime_config(profile="baseline", env={})
+        assert sources["torch_compile"] == "profile:baseline"
+
+    def test_env_overrides_profile(self):
+        cfg, sources = resolve_runtime_config(
+            profile="baseline", env={"WK_TORCH_COMPILE": "1"}
+        )
+        assert cfg.torch_compile is True
+        assert sources["torch_compile"] == "env:WK_TORCH_COMPILE"
+
+    def test_wk_disable_csv(self):
+        cfg, sources = resolve_runtime_config(env={"WK_DISABLE": "teacache,latent_pool"})
+        assert cfg.teacache is False
+        assert cfg.latent_pool is False
+        assert sources["teacache"] == "env:WK_DISABLE"
+
+    def test_wk_enable_csv(self):
+        cfg, _ = resolve_runtime_config(env={"WK_ENABLE": "teacache"})
+        assert cfg.teacache is True
+
+    def test_enum_env_override(self):
+        cfg, sources = resolve_runtime_config(env={"WK_ATTENTION_BACKEND": "sdpa"})
+        assert cfg.attention_backend == "sdpa"
+        assert sources["attention_backend"] == "env:WK_ATTENTION_BACKEND"
+
+    def test_enum_env_invalid_ignored(self):
+        cfg, sources = resolve_runtime_config(env={"WK_DTYPE": "garbage"})
+        assert cfg.dtype == "auto"
+        assert sources["dtype"] == "default"
+
+    def test_cli_overrides_everything(self):
+        cfg, sources = resolve_runtime_config(
+            profile="baseline",
+            env={"WK_TORCH_COMPILE": "1"},
+            cli_overrides={"torch_compile": False},
+        )
+        assert cfg.torch_compile is False
+        assert sources["torch_compile"] == "cli:--torch-compile"
+
+    def test_cli_none_is_ignored(self):
+        cfg, _ = resolve_runtime_config(cli_overrides={"teacache": None})
+        assert cfg.teacache is False  # default, not overridden

--- a/tests/config/test_profiles.py
+++ b/tests/config/test_profiles.py
@@ -47,9 +47,7 @@ class TestPrecedence:
         assert sources["torch_compile"] == "profile:baseline"
 
     def test_env_overrides_profile(self):
-        cfg, sources = resolve_runtime_config(
-            profile="baseline", env={"WK_TORCH_COMPILE": "1"}
-        )
+        cfg, sources = resolve_runtime_config(profile="baseline", env={"WK_TORCH_COMPILE": "1"})
         assert cfg.torch_compile is True
         assert sources["torch_compile"] == "env:WK_TORCH_COMPILE"
 

--- a/tests/config/test_runtime.py
+++ b/tests/config/test_runtime.py
@@ -1,0 +1,58 @@
+r"""RuntimeConfig + SessionOverrides shape and defaults."""
+
+from __future__ import annotations
+
+from worldkernels.config import EngineConfig, RuntimeConfig, SessionOverrides
+from worldkernels.config.runtime import (
+    ALL_TOGGLE_FIELDS,
+    SESSION_OVERRIDE_FIELDS,
+    TOGGLE_BOOL_FIELDS,
+    TOGGLE_ENUM_FIELDS,
+)
+
+
+class TestRuntimeConfigDefaults:
+    def test_default_preserves_current_behavior(self):
+        cfg = RuntimeConfig()
+        assert cfg.device == "cuda"
+        assert cfg.dtype == "auto"
+        assert cfg.max_sessions == 4
+        assert cfg.offload_idle is True
+        assert cfg.torch_compile is True
+        assert cfg.continuous_batching is True
+        assert cfg.quantization == "none"
+        assert cfg.attention_backend == "auto"
+        assert cfg.isolation == "auto"
+
+    def test_nested_subconfigs_present(self):
+        cfg = RuntimeConfig()
+        assert cfg.cache is not None
+        assert cfg.scheduler is not None
+        assert cfg.parallel is not None
+
+    def test_engineconfig_is_runtimeconfig_alias(self):
+        assert EngineConfig is RuntimeConfig
+        ec = EngineConfig(device="cpu", dtype="fp32")
+        assert isinstance(ec, RuntimeConfig)
+        assert ec.device == "cpu"
+
+    def test_toggle_field_registry_consistent(self):
+        cfg = RuntimeConfig()
+        for f in ALL_TOGGLE_FIELDS:
+            assert hasattr(cfg, f), f
+        for f in TOGGLE_BOOL_FIELDS:
+            assert isinstance(getattr(cfg, f), bool)
+        for f, allowed in TOGGLE_ENUM_FIELDS.items():
+            assert getattr(cfg, f) in allowed
+
+
+class TestSessionOverrides:
+    def test_defaults_are_none(self):
+        ov = SessionOverrides()
+        for f in SESSION_OVERRIDE_FIELDS:
+            assert getattr(ov, f) is None
+
+    def test_override_subset_is_safe_only(self):
+        # bake-time flags must NOT be expressible as session overrides
+        for unsafe in ("torch_compile", "cuda_graphs", "dtype", "quantization", "kv_cache_paged"):
+            assert unsafe not in SESSION_OVERRIDE_FIELDS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,18 +21,29 @@ from worldkernels.worlds import (
 
 @pytest.fixture(autouse=True)
 def _no_pip_install(monkeypatch):
-    r"""Hard guard: under no circumstances may a test trigger pip install or git clone."""
+    r"""Hard guard: under no circumstances may a test trigger pip/uv install, git clone, or venv materialization."""
     from worldkernels.bootstrap import deps as _deps
+    from worldkernels.runtime import envs as _envs
 
-    def _block_pip(card, progress=None, allow_fetch=True):
+    def _block_pip(card, progress=None, allow_fetch=True, target_python=None):
         return None
 
     def _block_git(card, progress=None, allow_fetch=True):
         return None
 
+    def _block_install(packages, target_python=None, progress=None, constraints=None):
+        return None
+
+    def _block_env(model_id, requirements, device="cuda", progress=None, allow_fetch=True):
+        raise AssertionError(
+            f"test triggered materialize_env({model_id!r}); add a monkeypatch if intended"
+        )
+
     monkeypatch.setattr(_hub, "ensure_model_deps", lambda model_id: None)
     monkeypatch.setattr(_deps, "provision_python_deps", _block_pip)
     monkeypatch.setattr(_deps, "provision_git_packages", _block_git)
+    monkeypatch.setattr(_deps, "install_packages", _block_install)
+    monkeypatch.setattr(_envs, "materialize_env", _block_env)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,8 +21,9 @@ from worldkernels.worlds import (
 
 @pytest.fixture(autouse=True)
 def _no_pip_install(monkeypatch):
-    r"""Hard guard: under no circumstances may a test trigger pip/uv install, git clone, or venv materialization."""
+    r"""Hard guard: under no circumstances may a test trigger pip/uv install, git clone, HF download, or venv materialization."""
     from worldkernels.bootstrap import deps as _deps
+    from worldkernels.bootstrap import weights as _weights
     from worldkernels.runtime import envs as _envs
 
     def _block_pip(card, progress=None, allow_fetch=True, target_python=None):
@@ -34,6 +35,11 @@ def _no_pip_install(monkeypatch):
     def _block_install(packages, target_python=None, progress=None, constraints=None):
         return None
 
+    def _block_weights(card, variant=None, ckpt_path=None, progress=None, allow_fetch=True):
+        if ckpt_path is not None:
+            return ckpt_path
+        return None
+
     def _block_env(model_id, requirements, device="cuda", progress=None, allow_fetch=True):
         raise AssertionError(
             f"test triggered materialize_env({model_id!r}); add a monkeypatch if intended"
@@ -43,6 +49,7 @@ def _no_pip_install(monkeypatch):
     monkeypatch.setattr(_deps, "provision_python_deps", _block_pip)
     monkeypatch.setattr(_deps, "provision_git_packages", _block_git)
     monkeypatch.setattr(_deps, "install_packages", _block_install)
+    monkeypatch.setattr(_weights, "provision_weights", _block_weights)
     monkeypatch.setattr(_envs, "materialize_env", _block_env)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 os.environ["WORLDKERNELS_NO_AUTO_INSTALL"] = "1"
+os.environ["WORLDKERNELS_QUIET"] = "1"
 
 from tests._helpers.factories import make_world_config  # noqa: E402
 from tests._helpers.mocks import MockWorld  # noqa: E402
@@ -20,8 +21,18 @@ from worldkernels.worlds import (
 
 @pytest.fixture(autouse=True)
 def _no_pip_install(monkeypatch):
-    r"""Hard guard: under no circumstances may a test trigger pip install."""
+    r"""Hard guard: under no circumstances may a test trigger pip install or git clone."""
+    from worldkernels.bootstrap import deps as _deps
+
+    def _block_pip(card, progress=None, allow_fetch=True):
+        return None
+
+    def _block_git(card, progress=None, allow_fetch=True):
+        return None
+
     monkeypatch.setattr(_hub, "ensure_model_deps", lambda model_id: None)
+    monkeypatch.setattr(_deps, "provision_python_deps", _block_pip)
+    monkeypatch.setattr(_deps, "provision_git_packages", _block_git)
 
 
 @pytest.fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,9 +21,8 @@ from worldkernels.worlds import (
 
 @pytest.fixture(autouse=True)
 def _no_pip_install(monkeypatch):
-    r"""Hard guard: under no circumstances may a test trigger pip/uv install, git clone, HF download, or venv materialization."""
-    from worldkernels.bootstrap import deps as _deps
-    from worldkernels.bootstrap import weights as _weights
+    r"""Block pip/uv install, git clone, HF download, and venv materialization in tests."""
+    from worldkernels.bootstrap import deps as _deps, weights as _weights
     from worldkernels.runtime import envs as _envs
 
     def _block_pip(card, progress=None, allow_fetch=True, target_python=None):

--- a/tests/runtime/test_ipc.py
+++ b/tests/runtime/test_ipc.py
@@ -2,7 +2,6 @@ r"""Tensor IPC: host-shm fallback path (CPU-only)."""
 
 from __future__ import annotations
 
-import numpy as np
 import pytest
 import torch
 

--- a/tests/runtime/test_ipc.py
+++ b/tests/runtime/test_ipc.py
@@ -1,0 +1,32 @@
+r"""Tensor IPC: host-shm fallback path (CPU-only)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from worldkernels.runtime import ipc
+
+
+@pytest.fixture(autouse=True)
+def _force_host_shm():
+    ipc.disable_cuda_ipc(True)
+    yield
+    ipc.disable_cuda_ipc(False)
+
+
+class TestHostShmFallback:
+    def test_share_and_recv_cpu_tensor(self):
+        src = torch.arange(12, dtype=torch.float32).reshape(3, 4)
+        handle = ipc.share_tensor(src)
+        assert handle.mode == "shm"
+        out = ipc.recv_tensor(handle)
+        torch.testing.assert_close(out, src)
+
+    def test_dtype_preserved(self):
+        src = torch.ones((2, 2), dtype=torch.int32)
+        handle = ipc.share_tensor(src)
+        out = ipc.recv_tensor(handle)
+        assert out.dtype == torch.int32
+        torch.testing.assert_close(out, src)

--- a/tests/runtime/test_locks.py
+++ b/tests/runtime/test_locks.py
@@ -1,0 +1,33 @@
+r"""Per-model lockfile + deps hash."""
+
+from __future__ import annotations
+
+from worldkernels.runtime import locks
+
+
+def test_deps_hash_stable_across_order(monkeypatch):
+    a = locks.deps_hash(["transformers==4.46", "diffusers==0.30"], "abi", "cuda")
+    b = locks.deps_hash(["diffusers==0.30", "transformers==4.46"], "abi", "cuda")
+    assert a == b
+
+
+def test_deps_hash_diverges_on_abi_change():
+    a = locks.deps_hash(["transformers==4.46"], "abi-A", "cuda")
+    b = locks.deps_hash(["transformers==4.46"], "abi-B", "cuda")
+    assert a != b
+
+
+def test_envlock_roundtrip(monkeypatch, tmp_path):
+    monkeypatch.setenv("WORLDKERNELS_HOME", str(tmp_path))
+    lock = locks.EnvLock(
+        model_id="org/m",
+        deps_hash="abc",
+        torch_abi="2.4-cu121",
+        device="cuda",
+        requirements=["transformers==4.46"],
+    )
+    lock.write()
+    got = locks.EnvLock.read("org/m")
+    assert got is not None
+    assert got.deps_hash == "abc"
+    assert got.requirements == ["transformers==4.46"]

--- a/tests/runtime/test_resolver.py
+++ b/tests/runtime/test_resolver.py
@@ -1,0 +1,59 @@
+r"""Resolver: SharedPlan vs IsolatedPlan decision (ADR-012)."""
+
+from __future__ import annotations
+
+import shutil
+
+import pytest
+
+from worldkernels.runtime import resolver
+from worldkernels.worlds.hub import ModelCard
+
+
+def _card(adapter: str, constraints: list[str] | None = None, isolation: str = "auto") -> ModelCard:
+    return ModelCard(
+        adapter=adapter,
+        constraints=constraints or [],
+        isolation=isolation,  # type: ignore[arg-type]
+    )
+
+
+class TestResolveInstallPlan:
+    def test_no_constraints_returns_shared(self):
+        card = _card("dummy")
+        plan = resolver.resolve_install_plan(card, [])
+        assert isinstance(plan, resolver.SharedPlan)
+
+    def test_forced_isolated_short_circuits(self):
+        card = _card("dummy", isolation="isolated", constraints=["torch>=2.0"])
+        plan = resolver.resolve_install_plan(card, [])
+        assert isinstance(plan, resolver.IsolatedPlan)
+        assert "isolated" in plan.reason
+
+    @pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+    def test_overlapping_ranges_share_env(self):
+        a = _card("a", constraints=["packaging>=20.0"])
+        b = _card("b", constraints=["packaging>=21.0"])
+        plan = resolver.resolve_install_plan(b, [a])
+        assert isinstance(plan, resolver.SharedPlan)
+
+    @pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+    def test_conflicting_pins_force_isolation(self):
+        a = _card("a", constraints=["packaging==20.0"])
+        b = _card("b", constraints=["packaging==99.0"])
+        plan = resolver.resolve_install_plan(b, [a])
+        assert isinstance(plan, resolver.IsolatedPlan)
+
+    @pytest.mark.skipif(shutil.which("uv") is None, reason="uv not installed")
+    def test_shared_forced_with_conflict_raises(self):
+        a = _card("a", constraints=["packaging==20.0"])
+        b = _card("b", constraints=["packaging==99.0"], isolation="shared")
+        with pytest.raises(resolver.IncompatibleDependenciesError):
+            resolver.resolve_install_plan(b, [a])
+
+    def test_uv_missing_falls_back_to_shared(self, monkeypatch):
+        monkeypatch.setattr(resolver.shutil, "which", lambda _: None)
+        a = _card("a", constraints=["packaging>=20.0"])
+        b = _card("b", constraints=["packaging>=21.0"])
+        plan = resolver.resolve_install_plan(b, [a])
+        assert isinstance(plan, resolver.SharedPlan)

--- a/tests/runtime/test_rpc.py
+++ b/tests/runtime/test_rpc.py
@@ -1,0 +1,67 @@
+r"""Round-trip an RPC request/response over a Unix socket."""
+
+from __future__ import annotations
+
+import sys
+import threading
+import time
+
+import pytest
+
+from worldkernels.runtime.rpc import RpcClient, RpcError, RpcServer, default_socket_path
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="Unix sockets only")
+class TestRpcRoundTrip:
+    def test_simple_call(self, tmp_path):
+        sock = tmp_path / "rpc.sock"
+        server = RpcServer(sock)
+
+        def handler(op, args):
+            if op == "echo":
+                return {"got": args.get("msg")}
+            if op == "close":
+                return {"ok": True}
+            raise ValueError(f"unknown op {op}")
+
+        t = threading.Thread(target=server.serve, args=(handler,), daemon=True)
+        t.start()
+
+        client = RpcClient(sock)
+        client.connect()
+        out = client.call("echo", msg="hello")
+        assert out == {"got": "hello"}
+        client.call("close")
+        t.join(timeout=2.0)
+        client.close()
+
+    def test_error_propagation(self, tmp_path):
+        sock = tmp_path / "rpc.sock"
+        server = RpcServer(sock)
+
+        def handler(op, args):
+            if op == "boom":
+                raise ValueError("nope")
+            if op == "close":
+                return {"ok": True}
+            return None
+
+        t = threading.Thread(target=server.serve, args=(handler,), daemon=True)
+        t.start()
+
+        client = RpcClient(sock)
+        client.connect()
+        with pytest.raises(RpcError) as ei:
+            client.call("boom")
+        assert "nope" in str(ei.value)
+        assert ei.value.exc_cls == "ValueError"
+        client.call("close")
+        client.close()
+        t.join(timeout=2.0)
+
+
+def test_default_socket_path_is_unique():
+    a = default_socket_path("foo")
+    time.sleep(0.001)
+    b = default_socket_path("foo")
+    assert a != b

--- a/tests/runtime/test_toggles.py
+++ b/tests/runtime/test_toggles.py
@@ -1,0 +1,391 @@
+r"""Per-toggle behavior assertions: every flag controls observable behavior.
+
+For each flag, we load an engine with it ON vs OFF, run the relevant code
+path, and assert the subsystem was either instantiated and exercised, or
+absent. Output shapes/types stay identical (graceful fallback) — only the
+side-channel evidence differs.
+"""
+
+from __future__ import annotations
+
+import torch
+
+from worldkernels import Action, WorldConfig, WorldEngine
+from worldkernels.config import RuntimeConfig
+from worldkernels.runtime.memory.kv_cache import KVCacheManager
+from worldkernels.runtime.memory.latent_pool import LatentPool
+from worldkernels.runtime.memory.trajectory_cache import TrajectoryCache
+
+
+def _step_dummy(engine: WorldEngine) -> None:
+    engine.load_model("dummy")
+    session = engine.create_session("dummy", config=WorldConfig(height=32, width=32))
+    session.step(Action("null", {}), modalities=["frames"])
+    session.close()
+
+
+class TestLatentPool:
+    def test_on_creates_pool_and_records_use(self):
+        wk = WorldEngine(RuntimeConfig(latent_pool=True), device="cpu")
+        try:
+            assert isinstance(wk._worker.runner.pool, LatentPool)
+            _step_dummy(wk)
+            # at least one acquire/release pair from DummyWorld.transition
+            assert wk._worker.runner.pool.num_pooled >= 1
+        finally:
+            wk.shutdown()
+
+    def test_off_pool_is_none(self):
+        wk = WorldEngine(RuntimeConfig(latent_pool=False), device="cpu")
+        try:
+            assert wk._worker.runner.pool is None
+            _step_dummy(wk)  # still works via the fallback path
+        finally:
+            wk.shutdown()
+
+
+class TestTeaCache:
+    def test_on_creates_cache_and_records_activity(self):
+        wk = WorldEngine(RuntimeConfig(teacache=True), device="cpu")
+        try:
+            cache = wk._worker.runner.teacache
+            assert cache is not None
+            _step_dummy(wk)
+            assert (cache.hits + cache.misses) >= 1
+        finally:
+            wk.shutdown()
+
+    def test_off_no_cache(self):
+        wk = WorldEngine(RuntimeConfig(teacache=False), device="cpu")
+        try:
+            assert wk._worker.runner.teacache is None
+            _step_dummy(wk)  # fallback path unchanged
+        finally:
+            wk.shutdown()
+
+
+class TestTrajectoryCache:
+    def test_on_creates_cache_and_match_returns_match(self):
+        wk = WorldEngine(RuntimeConfig(trajectory_cache=True), device="cpu")
+        try:
+            assert isinstance(wk.trajectory_cache, TrajectoryCache)
+            assert wk.cache_trajectory(["a", "b", "c"], [10, 11, 12])
+            match = wk.lookup_trajectory_prefix(["a", "b", "d"])
+            assert match is not None
+            assert match.length == 2
+            assert match.block_ids == [10, 11]
+        finally:
+            wk.shutdown()
+
+    def test_off_lookup_returns_none(self):
+        wk = WorldEngine(RuntimeConfig(trajectory_cache=False), device="cpu")
+        try:
+            assert wk.trajectory_cache is None
+            assert wk.lookup_trajectory_prefix(["a"]) is None
+            assert wk.cache_trajectory(["a"], [1]) is False
+        finally:
+            wk.shutdown()
+
+
+class TestKvCachePaged:
+    def test_on_ensures_kv_manager_for_causal_world(self, monkeypatch):
+        from tests._helpers.mocks import MockWorld
+        from worldkernels.worlds import registry as reg
+
+        class CausalWorld(MockWorld):
+            supports_kv_cache = True
+
+        reg.register_world("_causal_world", CausalWorld)
+        try:
+            wk = WorldEngine(RuntimeConfig(kv_cache_paged=True), device="cpu")
+            try:
+                wk.load_model("_causal_world")
+                assert isinstance(wk._worker.runner.kv_cache, KVCacheManager)
+                assert wk._worker.runner.block_manager is not None
+            finally:
+                wk.shutdown()
+        finally:
+            reg._REGISTRY.pop("_causal_world", None)
+
+    def test_off_kv_manager_stays_none(self, monkeypatch):
+        from tests._helpers.mocks import MockWorld
+        from worldkernels.worlds import registry as reg
+
+        class CausalWorld(MockWorld):
+            supports_kv_cache = True
+
+        reg.register_world("_causal_world_off", CausalWorld)
+        try:
+            wk = WorldEngine(RuntimeConfig(kv_cache_paged=False), device="cpu")
+            try:
+                wk.load_model("_causal_world_off")
+                assert wk._worker.runner.kv_cache is None
+                assert wk._worker.runner.block_manager is None
+            finally:
+                wk.shutdown()
+        finally:
+            reg._REGISTRY.pop("_causal_world_off", None)
+
+
+class TestIterationBatching:
+    def test_on_drives_transition_iter(self, monkeypatch):
+        wk = WorldEngine(RuntimeConfig(iteration_batching=True), device="cpu")
+        try:
+            wk.load_model("dummy")
+            world = wk._worlds["dummy"]
+            calls = {"iter": 0, "atomic": 0}
+            orig_iter = world.transition_iter
+            orig_t = world.transition
+
+            def spy_iter(state, action):
+                calls["iter"] += 1
+                yield from orig_iter(state, action)
+
+            def spy_t(state, action):
+                calls["atomic"] += 1
+                return orig_t(state, action)
+
+            monkeypatch.setattr(world, "transition_iter", spy_iter)
+            monkeypatch.setattr(world, "transition", spy_t)
+            session = wk.create_session("dummy", config=WorldConfig(height=32, width=32))
+            session.step(Action("null", {}), modalities=["frames"])
+            assert calls["iter"] == 1
+            assert calls["atomic"] == 0
+        finally:
+            wk.shutdown()
+
+    def test_off_drives_atomic_transition(self, monkeypatch):
+        wk = WorldEngine(RuntimeConfig(iteration_batching=False), device="cpu")
+        try:
+            wk.load_model("dummy")
+            world = wk._worlds["dummy"]
+            calls = {"iter": 0, "atomic": 0}
+            orig_iter = world.transition_iter
+            orig_t = world.transition
+
+            def spy_iter(state, action):
+                calls["iter"] += 1
+                yield from orig_iter(state, action)
+
+            def spy_t(state, action):
+                calls["atomic"] += 1
+                return orig_t(state, action)
+
+            monkeypatch.setattr(world, "transition_iter", spy_iter)
+            monkeypatch.setattr(world, "transition", spy_t)
+            session = wk.create_session("dummy", config=WorldConfig(height=32, width=32))
+            session.step(Action("null", {}), modalities=["frames"])
+            assert calls["iter"] == 0
+            assert calls["atomic"] == 1
+        finally:
+            wk.shutdown()
+
+
+class TestOffloadIdle:
+    def test_on_offloads_non_active(self):
+        import asyncio
+
+        async def scenario():
+            from worldkernels.core.session import LatentState
+            from worldkernels.engine import AsyncEngine
+
+            wk = WorldEngine(RuntimeConfig(offload_idle=True), device="cpu")
+            try:
+                wk.load_model("dummy")
+                ae = AsyncEngine(wk, batch_window=0.001)
+                cfg = WorldConfig(height=32, width=32)
+                sess_a = wk.create_session("dummy", config=cfg)
+                sess_b = wk.create_session("dummy", config=cfg)
+                sess_b.state = LatentState(data=sess_b.state.data, device="cuda:0")
+                await ae.step(sess_a.session_id, Action("null", {}))
+                await asyncio.sleep(0.01)
+                assert ae.offload_count >= 1
+                await ae.shutdown()
+            finally:
+                wk.shutdown()
+
+        asyncio.run(scenario())
+
+    def test_off_does_not_offload(self):
+        import asyncio
+
+        async def scenario():
+            from worldkernels.core.session import LatentState
+            from worldkernels.engine import AsyncEngine
+
+            wk = WorldEngine(RuntimeConfig(offload_idle=False), device="cpu")
+            try:
+                wk.load_model("dummy")
+                ae = AsyncEngine(wk, batch_window=0.001)
+                cfg = WorldConfig(height=32, width=32)
+                sess_a = wk.create_session("dummy", config=cfg)
+                sess_b = wk.create_session("dummy", config=cfg)
+                sess_b.state = LatentState(data=sess_b.state.data, device="cuda:0")
+                await ae.step(sess_a.session_id, Action("null", {}))
+                await asyncio.sleep(0.01)
+                assert ae.offload_count == 0
+                await ae.shutdown()
+            finally:
+                wk.shutdown()
+
+        asyncio.run(scenario())
+
+
+class TestAttentionBackend:
+    def test_selector_reads_forward_context_sdpa(self):
+        from worldkernels.runtime.attention.backends import SDPABackend
+        from worldkernels.runtime.attention.selector import select_attention_backend
+        from worldkernels.runtime.forward_context import ForwardContext, set_forward_context
+
+        with set_forward_context(ForwardContext(attention_backend="sdpa")):
+            backend = select_attention_backend()
+        assert isinstance(backend, SDPABackend)
+
+    def test_selector_falls_back_to_platform_default_when_ctx_none(self):
+        from worldkernels.runtime.attention.selector import select_attention_backend
+        from worldkernels.runtime.forward_context import ForwardContext, set_forward_context
+
+        with set_forward_context(ForwardContext(attention_backend=None)):
+            backend = select_attention_backend()
+        assert backend is not None  # one of SDPA / Flash
+
+    def test_runner_threads_attention_backend_into_context(self):
+        wk = WorldEngine(
+            RuntimeConfig(attention_backend="sdpa", iteration_batching=False), device="cpu"
+        )
+        try:
+            wk.load_model("dummy")
+            seen = {}
+
+            from worldkernels.runtime.forward_context import get_forward_context
+
+            orig = wk._worlds["dummy"].transition
+
+            def spy(state, action):
+                ctx = get_forward_context()
+                seen["backend"] = ctx.attention_backend
+                return orig(state, action)
+
+            wk._worlds["dummy"].transition = spy
+            session = wk.create_session("dummy", config=WorldConfig(height=32, width=32))
+            session.step(Action("null", {}), modalities=["frames"])
+            assert seen["backend"] == "sdpa"
+        finally:
+            wk.shutdown()
+
+
+class TestQuantization:
+    def test_none_does_not_call_registry(self, monkeypatch):
+        from worldkernels.runtime.quantization.registry import QuantizationRegistry
+
+        called = {"n": 0}
+
+        def spy(self, module, scheme):
+            called["n"] += 1
+            return module
+
+        monkeypatch.setattr(QuantizationRegistry, "apply", spy)
+        wk = WorldEngine(RuntimeConfig(quantization="none"), device="cpu")
+        try:
+            wk.load_model("dummy")
+            assert called["n"] == 0
+        finally:
+            wk.shutdown()
+
+    def test_int8_invokes_registry_with_target(self, monkeypatch):
+        from worldkernels.runtime.quantization.registry import QuantizationRegistry
+
+        recorded = {}
+
+        def spy(self, module, scheme):
+            recorded["scheme"] = scheme
+            recorded["module"] = module
+            return module
+
+        monkeypatch.setattr(QuantizationRegistry, "apply", spy)
+        wk = WorldEngine(RuntimeConfig(quantization="int8"), device="cpu")
+        try:
+            wk.load_model("dummy")
+            assert recorded["scheme"] == "int8"
+            assert isinstance(recorded["module"], torch.nn.Linear)
+        finally:
+            wk.shutdown()
+
+
+class TestSessionOverrides:
+    def test_session_teacache_override_disables_recording(self):
+        wk = WorldEngine(RuntimeConfig(teacache=True), device="cpu")
+        try:
+            wk.load_model("dummy")
+            cfg = WorldConfig(height=32, width=32)
+            s_off = wk.create_session("dummy", config=cfg, overrides={"teacache": False})
+            s_on = wk.create_session("dummy", config=cfg)
+            # cache exists at the runner level
+            cache = wk._worker.runner.teacache
+            before = cache.hits + cache.misses
+            s_off.step(Action("null", {}), modalities=["frames"])
+            mid = cache.hits + cache.misses
+            s_on.step(Action("null", {}), modalities=["frames"])
+            after = cache.hits + cache.misses
+            assert mid == before     # session-off didn't touch the cache
+            assert after > mid       # session-on did
+        finally:
+            wk.shutdown()
+
+    def test_session_iteration_batching_override(self, monkeypatch):
+        wk = WorldEngine(RuntimeConfig(iteration_batching=True), device="cpu")
+        try:
+            wk.load_model("dummy")
+            world = wk._worlds["dummy"]
+            calls = {"iter": 0, "atomic": 0}
+            orig_iter = world.transition_iter
+            orig_t = world.transition
+
+            def spy_iter(state, action):
+                calls["iter"] += 1
+                yield from orig_iter(state, action)
+
+            def spy_t(state, action):
+                calls["atomic"] += 1
+                return orig_t(state, action)
+
+            monkeypatch.setattr(world, "transition_iter", spy_iter)
+            monkeypatch.setattr(world, "transition", spy_t)
+
+            cfg = WorldConfig(height=32, width=32)
+            s = wk.create_session("dummy", config=cfg, overrides={"iteration_batching": False})
+            s.step(Action("null", {}), modalities=["frames"])
+            assert calls["atomic"] == 1
+            assert calls["iter"] == 0
+        finally:
+            wk.shutdown()
+
+    def test_unsafe_override_warns_and_drops(self, caplog):
+        import logging
+
+        wk = WorldEngine(device="cpu")
+        try:
+            wk.load_model("dummy")
+            with caplog.at_level(logging.WARNING):
+                s = wk.create_session("dummy", overrides={"torch_compile": False})
+            assert s.overrides is None or "torch_compile" not in s.overrides
+            assert any("torch_compile" in r.message for r in caplog.records)
+        finally:
+            wk.shutdown()
+
+
+class TestGracefulFallbackShapes:
+    def test_dummy_step_output_shape_invariant_under_pool(self):
+        outputs = []
+        for pool_on in (True, False):
+            wk = WorldEngine(RuntimeConfig(latent_pool=pool_on), device="cpu")
+            try:
+                wk.load_model("dummy")
+                cfg = WorldConfig(height=32, width=32)
+                session = wk.create_session("dummy", config=cfg)
+                obs = session.step(Action("null", {}), modalities=["frames"])
+                outputs.append((len(obs.frames) if obs.frames else 0, obs.step_index))
+                session.close()
+            finally:
+                wk.shutdown()
+        assert outputs[0] == outputs[1]

--- a/tests/runtime/test_toggles.py
+++ b/tests/runtime/test_toggles.py
@@ -327,8 +327,8 @@ class TestSessionOverrides:
             mid = cache.hits + cache.misses
             s_on.step(Action("null", {}), modalities=["frames"])
             after = cache.hits + cache.misses
-            assert mid == before     # session-off didn't touch the cache
-            assert after > mid       # session-on did
+            assert mid == before  # session-off didn't touch the cache
+            assert after > mid  # session-on did
         finally:
             wk.shutdown()
 

--- a/tests/serving/test_routes.py
+++ b/tests/serving/test_routes.py
@@ -43,6 +43,29 @@ class TestWorldRoutes:
         assert r.status_code == 200
         assert r.json()["status"] == "unloaded"
 
+    def test_get_config_returns_resolved(self, client):
+        r = client.get("/v1/config")
+        assert r.status_code == 200
+        body = r.json()
+        assert "config" in body
+        assert "torch_compile" in body["config"]
+        assert "value" in body["config"]["torch_compile"]
+        assert "source" in body["config"]["torch_compile"]
+
+    def test_create_session_with_overrides(self, client):
+        body = client.post(
+            "/v1/sessions",
+            json={
+                "world": "dummy",
+                "height": 32,
+                "width": 32,
+                "frames_per_step": 1,
+                "overrides": {"teacache": False},
+            },
+        ).json()
+        sess = client.app.state.engine.get_session(body["session_id"])
+        assert sess.overrides == {"teacache": False}
+
     def test_unload_unknown_404(self, client):
         r = client.delete("/v1/worlds/missing_xyz")
         assert r.status_code == 404
@@ -235,7 +258,11 @@ class TestRouteErrors:
         def fake_transition(*a, **kw):
             raise WorldKernelError("internal")
 
+        def fake_transition_iter(*a, **kw):
+            raise WorldKernelError("internal")
+
         monkeypatch.setattr(sess._world, "transition", fake_transition)
+        monkeypatch.setattr(sess._world, "transition_iter", fake_transition_iter)
         r = client.post(f"/v1/sessions/{body['session_id']}/step", json={"action_type": "null"})
         assert r.status_code == 500
 

--- a/worldkernels/bootstrap/__init__.py
+++ b/worldkernels/bootstrap/__init__.py
@@ -1,0 +1,33 @@
+r"""Lazy model bootstrap: resolve ref, provision deps, fetch weights."""
+
+from __future__ import annotations
+
+import importlib as _importlib
+
+__all__ = [
+    "prepare",
+    "PreparedModel",
+    "ProgressController",
+    "BootstrapError",
+    "FetchDisabledError",
+    "AuthRequiredError",
+]
+
+_LAZY_IMPORTS: dict[str, tuple[str, str]] = {
+    "prepare": ("worldkernels.bootstrap.pipeline", "prepare"),
+    "PreparedModel": ("worldkernels.bootstrap.pipeline", "PreparedModel"),
+    "ProgressController": ("worldkernels.bootstrap.progress", "ProgressController"),
+    "BootstrapError": ("worldkernels.bootstrap.errors", "BootstrapError"),
+    "FetchDisabledError": ("worldkernels.bootstrap.errors", "FetchDisabledError"),
+    "AuthRequiredError": ("worldkernels.bootstrap.errors", "AuthRequiredError"),
+}
+
+
+def __getattr__(name: str):
+    if name in _LAZY_IMPORTS:
+        module_path, attr = _LAZY_IMPORTS[name]
+        mod = _importlib.import_module(module_path)
+        val = getattr(mod, attr)
+        globals()[name] = val
+        return val
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/worldkernels/bootstrap/cache.py
+++ b/worldkernels/bootstrap/cache.py
@@ -1,0 +1,100 @@
+r"""Cache layout: WORLDKERNELS_HOME with packages/, manifests/."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def home() -> Path:
+    env = os.environ.get("WORLDKERNELS_HOME")
+    if env:
+        return Path(env).expanduser()
+    return Path.home() / ".cache" / "worldkernels"
+
+
+def packages_dir() -> Path:
+    p = home() / "packages"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def manifests_dir() -> Path:
+    p = home() / "manifests"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+@dataclass
+class Manifest:
+    model_id: str
+    variant: str | None = None
+    adapter: str = ""
+    hf_repo: str | None = None
+    ckpt_path: str | None = None
+    pip_extra: str | None = None
+    git_packages: list[str] = field(default_factory=list)
+    created_at: str = ""
+
+    def write(self) -> None:
+        path = manifests_dir() / f"{_slug(self.model_id, self.variant)}.json"
+        self.created_at = self.created_at or datetime.now(timezone.utc).isoformat()
+        path.write_text(json.dumps(asdict(self), indent=2))
+
+    @classmethod
+    def read(cls, model_id: str, variant: str | None = None) -> "Manifest | None":
+        path = manifests_dir() / f"{_slug(model_id, variant)}.json"
+        if not path.exists():
+            return None
+        return cls(**json.loads(path.read_text()))
+
+
+def list_manifests() -> list[Manifest]:
+    out: list[Manifest] = []
+    for p in manifests_dir().glob("*.json"):
+        try:
+            out.append(Manifest(**json.loads(p.read_text())))
+        except Exception:
+            continue
+    return out
+
+
+def remove_manifest(model_id: str, variant: str | None = None) -> bool:
+    path = manifests_dir() / f"{_slug(model_id, variant)}.json"
+    if path.exists():
+        path.unlink()
+        return True
+    return False
+
+
+def _slug(model_id: str, variant: str | None) -> str:
+    s = model_id.replace("/", "_").replace(":", "_")
+    if variant:
+        s = f"{s}__{variant}"
+    return s
+
+
+def directory_size_bytes(path: Path) -> int:
+    if not path.exists():
+        return 0
+    total = 0
+    for p in path.rglob("*"):
+        if p.is_file():
+            try:
+                total += p.stat().st_size
+            except OSError:
+                pass
+    return total
+
+
+def hf_cache_size_bytes(repo_id: str) -> int:
+    try:
+        from huggingface_hub import scan_cache_dir
+
+        info = scan_cache_dir()
+        return sum(repo.size_on_disk for repo in info.repos if repo.repo_id == repo_id)
+    except Exception:
+        return 0

--- a/worldkernels/bootstrap/deps.py
+++ b/worldkernels/bootstrap/deps.py
@@ -95,9 +95,7 @@ def install_packages(
             progress.event("deps", "failed", f"install failed (exit {proc.returncode})")
         if quiet:
             sys.stderr.write((proc.stdout or "") + "\n" + (proc.stderr or "") + "\n")
-        raise RuntimeError(
-            f"install failed for {packages!r} via {runner} (exit {proc.returncode})"
-        )
+        raise RuntimeError(f"install failed for {packages!r} via {runner} (exit {proc.returncode})")
 
 
 def _select_installer() -> str:

--- a/worldkernels/bootstrap/deps.py
+++ b/worldkernels/bootstrap/deps.py
@@ -1,4 +1,4 @@
-r"""Provision python deps (pip) and native packages (git clone) with progress."""
+r"""Provision python deps (uv) and native packages (git clone) with progress."""
 
 from __future__ import annotations
 
@@ -32,6 +32,7 @@ def provision_python_deps(
     card: "ModelCard",
     progress: "ProgressController | None" = None,
     allow_fetch: bool = True,
+    target_python: str | None = None,
 ) -> None:
     extra = card.pip_extra
     if extra is None:
@@ -40,13 +41,14 @@ def provision_python_deps(
         return
 
     sentinel = _EXTRA_SENTINELS.get(extra, extra)
-    try:
-        importlib.import_module(sentinel)
-        if progress is not None:
-            progress.event("deps", "skipped", f"{extra} already installed")
-        return
-    except ImportError:
-        pass
+    if target_python is None:
+        try:
+            importlib.import_module(sentinel)
+            if progress is not None:
+                progress.event("deps", "skipped", f"{extra} already installed")
+            return
+        except ImportError:
+            pass
 
     if not allow_fetch or os.environ.get("WORLDKERNELS_NO_AUTO_INSTALL"):
         raise FetchDisabledError(
@@ -56,24 +58,68 @@ def provision_python_deps(
 
     pkg = f"worldkernels[{extra}]"
     if progress is not None:
-        progress.event("deps", "running", f"pip install '{pkg}' …")
-    log.info("Auto-installing missing dependencies: pip install '%s'", pkg)
+        progress.event("deps", "running", f"installing '{pkg}' …")
+    log.info("Auto-installing missing dependencies: %s", pkg)
 
-    cmd = [sys.executable, "-m", "pip", "install", "--disable-pip-version-check", pkg]
-    quiet = progress is not None and progress.mode == "tty"
-    if quiet:
-        cmd.append("--quiet")
-
-    proc = subprocess.run(cmd, check=False, capture_output=quiet, text=True)
-    if proc.returncode != 0:
-        if progress is not None:
-            progress.event("deps", "failed", f"pip install failed (exit {proc.returncode})")
-        if quiet:
-            sys.stderr.write(proc.stdout + "\n" + proc.stderr + "\n")
-        raise RuntimeError(f"pip install '{pkg}' failed (exit {proc.returncode})")
+    install_packages([pkg], target_python=target_python, progress=progress)
 
     if progress is not None:
         progress.event("deps", "done", f"installed {extra}")
+
+
+def install_packages(
+    packages: list[str],
+    target_python: str | None = None,
+    progress: "ProgressController | None" = None,
+    constraints: str | None = None,
+) -> None:
+    r"""Install pip packages into the target python via uv (pip fallback).
+
+    Args:
+        packages: PEP 508 package specs.
+        target_python: Python interpreter to install into (defaults to the current one).
+        progress: Optional progress controller for live status updates.
+        constraints: Optional path to a requirements/lock constraints file.
+    """
+    if not packages:
+        return
+    python_exe = target_python or sys.executable
+    runner = _select_installer()
+    cmd = _build_install_cmd(runner, packages, python_exe, constraints)
+    quiet = progress is not None and progress.mode in ("tty", "quiet", "json", "sink")
+
+    log.debug("Running install: %s", " ".join(cmd))
+    proc = subprocess.run(cmd, check=False, capture_output=quiet, text=True)
+    if proc.returncode != 0:
+        if progress is not None:
+            progress.event("deps", "failed", f"install failed (exit {proc.returncode})")
+        if quiet:
+            sys.stderr.write((proc.stdout or "") + "\n" + (proc.stderr or "") + "\n")
+        raise RuntimeError(
+            f"install failed for {packages!r} via {runner} (exit {proc.returncode})"
+        )
+
+
+def _select_installer() -> str:
+    if shutil.which("uv") is not None:
+        return "uv"
+    return "pip"
+
+
+def _build_install_cmd(
+    runner: str, packages: list[str], python_exe: str, constraints: str | None
+) -> list[str]:
+    if runner == "uv":
+        cmd = ["uv", "pip", "install", "--python", python_exe]
+        if constraints:
+            cmd += ["--constraint", constraints]
+        cmd += packages
+        return cmd
+    cmd = [python_exe, "-m", "pip", "install", "--disable-pip-version-check"]
+    if constraints:
+        cmd += ["--constraint", constraints]
+    cmd += packages
+    return cmd
 
 
 def provision_git_packages(

--- a/worldkernels/bootstrap/deps.py
+++ b/worldkernels/bootstrap/deps.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import subprocess
 import sys
-from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -206,14 +205,3 @@ def _is_valid(path: Path, import_check: str | None) -> bool:
     if import_check is None:
         return True
     return (path / import_check.replace(".", "/") / "__init__.py").exists()
-
-
-@dataclass
-class GitPackage:
-    r"""Spec for a github-only python package fetched on first use."""
-
-    name: str
-    url: str
-    import_check: str | None = None
-    env_path_var: str | None = None
-    ref: str | None = None

--- a/worldkernels/bootstrap/deps.py
+++ b/worldkernels/bootstrap/deps.py
@@ -1,0 +1,175 @@
+r"""Provision python deps (pip) and native packages (git clone) with progress."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from worldkernels.bootstrap import cache
+from worldkernels.bootstrap.errors import FetchDisabledError
+
+if TYPE_CHECKING:
+    from worldkernels.bootstrap.progress import ProgressController
+    from worldkernels.worlds.hub import GitPackage, ModelCard
+
+log = logging.getLogger(__name__)
+
+
+_EXTRA_SENTINELS: dict[str, str] = {
+    "cosmos": "transformers",
+    "diffusion": "diffusers",
+}
+
+
+def provision_python_deps(
+    card: "ModelCard",
+    progress: "ProgressController | None" = None,
+    allow_fetch: bool = True,
+) -> None:
+    extra = card.pip_extra
+    if extra is None:
+        if progress is not None:
+            progress.event("deps", "skipped", "none required")
+        return
+
+    sentinel = _EXTRA_SENTINELS.get(extra, extra)
+    try:
+        importlib.import_module(sentinel)
+        if progress is not None:
+            progress.event("deps", "skipped", f"{extra} already installed")
+        return
+    except ImportError:
+        pass
+
+    if not allow_fetch or os.environ.get("WORLDKERNELS_NO_AUTO_INSTALL"):
+        raise FetchDisabledError(
+            f"missing python deps for '{card.adapter}' (extra: {extra})",
+            f"install with: pip install 'worldkernels[{extra}]'",
+        )
+
+    pkg = f"worldkernels[{extra}]"
+    if progress is not None:
+        progress.event("deps", "running", f"pip install '{pkg}' …")
+    log.info("Auto-installing missing dependencies: pip install '%s'", pkg)
+
+    cmd = [sys.executable, "-m", "pip", "install", "--disable-pip-version-check", pkg]
+    quiet = progress is not None and progress.mode == "tty"
+    if quiet:
+        cmd.append("--quiet")
+
+    proc = subprocess.run(cmd, check=False, capture_output=quiet, text=True)
+    if proc.returncode != 0:
+        if progress is not None:
+            progress.event("deps", "failed", f"pip install failed (exit {proc.returncode})")
+        if quiet:
+            sys.stderr.write(proc.stdout + "\n" + proc.stderr + "\n")
+        raise RuntimeError(f"pip install '{pkg}' failed (exit {proc.returncode})")
+
+    if progress is not None:
+        progress.event("deps", "done", f"installed {extra}")
+
+
+def provision_git_packages(
+    card: "ModelCard",
+    progress: "ProgressController | None" = None,
+    allow_fetch: bool = True,
+) -> None:
+    if not card.git_packages:
+        if progress is not None:
+            progress.event("packages", "skipped", "none required")
+        return
+
+    if progress is not None:
+        progress.event("packages", "running", "checking …")
+
+    installed: list[str] = []
+    for gp in card.git_packages:
+        path = _ensure_git_package(gp, progress=progress, allow_fetch=allow_fetch)
+        if path is not None and str(path) not in sys.path:
+            sys.path.insert(0, str(path))
+        installed.append(gp.name)
+
+    if progress is not None:
+        progress.event("packages", "done", ", ".join(installed))
+
+
+def _ensure_git_package(
+    gp: "GitPackage",
+    progress: "ProgressController | None" = None,
+    allow_fetch: bool = True,
+) -> Path | None:
+    if gp.env_path_var:
+        env_path = os.environ.get(gp.env_path_var)
+        if env_path and _is_valid(Path(env_path), gp.import_check):
+            return Path(env_path)
+
+    for candidate in _candidate_paths(gp):
+        if _is_valid(candidate, gp.import_check):
+            return candidate
+
+    dest = cache.packages_dir() / gp.name
+
+    if dest.exists() and _is_valid(dest, gp.import_check):
+        return dest
+
+    if not allow_fetch or os.environ.get("WORLDKERNELS_NO_AUTO_INSTALL"):
+        raise FetchDisabledError(
+            f"missing git package '{gp.name}'",
+            f"clone {gp.url} to {dest} or set ${gp.env_path_var}",
+        )
+
+    if shutil.which("git") is None:
+        raise RuntimeError(
+            f"git not found on PATH; cannot fetch {gp.name}. Install git or set ${gp.env_path_var}."
+        )
+
+    if progress is not None:
+        progress.event("packages", "running", f"cloning {gp.url} …")
+    log.info("Cloning %s to %s", gp.url, dest)
+
+    args = ["git", "clone", "--depth=1"]
+    if gp.ref:
+        args += ["--branch", gp.ref]
+    args += [gp.url, str(dest)]
+
+    proc = subprocess.run(args, check=False, capture_output=True, text=True, timeout=600)
+    if proc.returncode != 0:
+        if progress is not None:
+            progress.event("packages", "failed", f"clone failed: {gp.url}")
+        sys.stderr.write(proc.stderr)
+        raise RuntimeError(f"git clone failed for {gp.url}")
+
+    return dest
+
+
+def _candidate_paths(gp: "GitPackage") -> list[Path]:
+    return [
+        Path.home() / gp.name,
+        Path.home() / gp.url.rstrip("/").rsplit("/", 1)[-1].removesuffix(".git"),
+    ]
+
+
+def _is_valid(path: Path, import_check: str | None) -> bool:
+    if not path.exists():
+        return False
+    if import_check is None:
+        return True
+    return (path / import_check.replace(".", "/") / "__init__.py").exists()
+
+
+@dataclass
+class GitPackage:
+    r"""Spec for a github-only python package fetched on first use."""
+
+    name: str
+    url: str
+    import_check: str | None = None
+    env_path_var: str | None = None
+    ref: str | None = None

--- a/worldkernels/bootstrap/errors.py
+++ b/worldkernels/bootstrap/errors.py
@@ -1,0 +1,25 @@
+r"""Bootstrap-specific errors. Surfaced cleanly to CLI/HTTP without tracebacks."""
+
+from __future__ import annotations
+
+from worldkernels.core.errors import WorldKernelError
+
+
+class BootstrapError(WorldKernelError):
+    pass
+
+
+class FetchDisabledError(BootstrapError):
+    def __init__(self, what: str, hint: str) -> None:
+        super().__init__(f"{what} (auto-fetch disabled). {hint}")
+
+
+class AuthRequiredError(BootstrapError):
+    def __init__(self, repo: str) -> None:
+        super().__init__(
+            f"Model '{repo}' is gated. Run `huggingface-cli login` and retry."
+        )
+
+
+class ModelNotFoundError(BootstrapError):
+    pass

--- a/worldkernels/bootstrap/errors.py
+++ b/worldkernels/bootstrap/errors.py
@@ -16,9 +16,7 @@ class FetchDisabledError(BootstrapError):
 
 class AuthRequiredError(BootstrapError):
     def __init__(self, repo: str) -> None:
-        super().__init__(
-            f"Model '{repo}' is gated. Run `huggingface-cli login` and retry."
-        )
+        super().__init__(f"Model '{repo}' is gated. Run `huggingface-cli login` and retry.")
 
 
 class ModelNotFoundError(BootstrapError):

--- a/worldkernels/bootstrap/installer.py
+++ b/worldkernels/bootstrap/installer.py
@@ -1,0 +1,83 @@
+r"""Installer dispatch: Shared vs Isolated tier (ADR-012).
+
+The shared installer puts deps into the running interpreter's env (the same
+path the lazy bootstrap has always used). The isolated installer materializes
+a per-model uv venv and returns its path; the engine then spawns a worker
+inside that venv via `RemoteWorld`.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
+
+if TYPE_CHECKING:
+    from worldkernels.bootstrap.progress import ProgressController
+    from worldkernels.worlds.hub import ModelCard
+
+log = logging.getLogger(__name__)
+
+__all__ = ["Installer", "SharedInstaller", "IsolatedInstaller", "InstallResult"]
+
+
+@dataclass
+class InstallResult:
+    r"""Where the model's deps now live."""
+
+    tier: str  # "shared" | "isolated"
+    env_path: Path | None = None
+
+
+class Installer(Protocol):
+    def install(
+        self,
+        card: "ModelCard",
+        progress: "ProgressController | None",
+        allow_fetch: bool,
+    ) -> InstallResult: ...
+
+
+class SharedInstaller:
+    r"""Install card's pip_extra (and git packages) into the current interpreter."""
+
+    def install(
+        self,
+        card: "ModelCard",
+        progress: "ProgressController | None",
+        allow_fetch: bool,
+    ) -> InstallResult:
+        from worldkernels.bootstrap import deps
+
+        deps.provision_python_deps(card, progress=progress, allow_fetch=allow_fetch)
+        deps.provision_git_packages(card, progress=progress, allow_fetch=allow_fetch)
+        return InstallResult(tier="shared", env_path=None)
+
+
+class IsolatedInstaller:
+    r"""Materialize a per-model uv venv and install the card's deps into it."""
+
+    def __init__(self, model_id: str, requirements: list[str], device: str = "cuda") -> None:
+        self.model_id = model_id
+        self.requirements = requirements
+        self.device = device
+
+    def install(
+        self,
+        card: "ModelCard",
+        progress: "ProgressController | None",
+        allow_fetch: bool,
+    ) -> InstallResult:
+        from worldkernels.runtime import envs
+
+        if progress is not None:
+            progress.event("isolating", "running", f"materializing env for {self.model_id} …")
+        env_path = envs.materialize_env(
+            self.model_id,
+            self.requirements,
+            device=self.device,
+            progress=progress,
+            allow_fetch=allow_fetch,
+        )
+        return InstallResult(tier="isolated", env_path=env_path)

--- a/worldkernels/bootstrap/pipeline.py
+++ b/worldkernels/bootstrap/pipeline.py
@@ -36,8 +36,9 @@ def prepare(
     actual instantiate/warmup so it can update the phase to ``done``).
     """
     owns_progress = progress is None
-    if owns_progress:
+    if progress is None:
         progress = ProgressController(mode="auto").__enter__()
+    assert progress is not None
 
     try:
         progress.event("resolve", "running", ref)

--- a/worldkernels/bootstrap/pipeline.py
+++ b/worldkernels/bootstrap/pipeline.py
@@ -1,0 +1,98 @@
+r"""bootstrap.prepare — single entrypoint that drives all five phases."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from worldkernels.bootstrap import cache, deps, resolve, weights
+from worldkernels.bootstrap.progress import ProgressController
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class PreparedModel:
+    adapter: str
+    alias: str
+    variant: str | None
+    kwargs: dict[str, Any] = field(default_factory=dict)
+    ckpt_path: str | None = None
+
+
+def prepare(
+    ref: str,
+    variant: str | None = None,
+    ckpt_path: str | None = None,
+    progress: ProgressController | None = None,
+    allow_fetch: bool = True,
+    **adapter_kwargs: Any,
+) -> PreparedModel:
+    r"""Resolve a ref and provision everything needed to load it.
+
+    Drives the five phases in order: resolve → deps → packages → weights → init
+    (the ``init`` phase is just marked as ``running`` here; the caller does the
+    actual instantiate/warmup so it can update the phase to ``done``).
+    """
+    owns_progress = progress is None
+    if owns_progress:
+        progress = ProgressController(mode="auto").__enter__()
+
+    try:
+        progress.event("resolve", "running", ref)
+        resolved = resolve.resolve(ref, variant=variant, ckpt_path=ckpt_path)
+        variant_str = f" (variant {resolved.variant})" if resolved.variant else ""
+        progress.event("resolve", "done", f"{resolved.name}{variant_str}")
+
+        deps.provision_python_deps(resolved.card, progress=progress, allow_fetch=allow_fetch)
+        deps.provision_git_packages(resolved.card, progress=progress, allow_fetch=allow_fetch)
+
+        local_path = weights.provision_weights(
+            resolved.card,
+            variant=resolved.variant,
+            ckpt_path=resolved.ckpt_path,
+            progress=progress,
+            allow_fetch=allow_fetch,
+        )
+
+        progress.event("init", "running", "loading …")
+
+        merged: dict[str, Any] = {**resolved.card.default_kwargs}
+        if resolved.variant is not None:
+            merged["variant"] = resolved.variant
+        if local_path is not None and resolved.ckpt_path is not None:
+            merged["ckpt_path"] = local_path
+        if resolved.card.generator is not None:
+            merged.setdefault("generator", resolved.card.generator)
+        merged.update(adapter_kwargs)
+
+        alias = adapter_kwargs.get("alias") or _alias_for(resolved)
+        manifest = cache.Manifest(
+            model_id=resolved.name,
+            variant=resolved.variant,
+            adapter=resolved.card.adapter,
+            hf_repo=resolved.card.hf_repo,
+            ckpt_path=local_path,
+            pip_extra=resolved.card.pip_extra,
+            git_packages=[gp.name for gp in resolved.card.git_packages],
+        )
+        manifest.write()
+
+        return PreparedModel(
+            adapter=resolved.card.adapter,
+            alias=alias,
+            variant=resolved.variant,
+            kwargs=merged,
+            ckpt_path=local_path,
+        )
+    finally:
+        if owns_progress:
+            progress.__exit__(None, None, None)
+
+
+def _alias_for(resolved: resolve.ResolvedRef) -> str:
+    base = resolved.name.split("/")[-1]
+    if resolved.variant:
+        return f"{base}:{resolved.variant}"
+    return base

--- a/worldkernels/bootstrap/progress.py
+++ b/worldkernels/bootstrap/progress.py
@@ -1,0 +1,177 @@
+r"""Unified progress UI for the bootstrap pipeline.
+
+Modes:
+- ``tty``: rich live panel with per-phase status, glyphs, and bar
+- ``plain``: one log line per phase transition
+- ``quiet``: silent except for errors
+- ``json``: structured one-event-per-line stdout (used by SSE)
+"""
+
+from __future__ import annotations
+
+import json as _json
+import logging
+import os
+import sys
+from dataclasses import dataclass
+from typing import Any, Callable, Literal
+
+log = logging.getLogger(__name__)
+
+PhaseStatus = Literal["pending", "running", "done", "skipped", "failed"]
+
+PHASES: tuple[str, ...] = ("resolve", "deps", "packages", "weights", "init")
+_LABELS: dict[str, str] = {
+    "resolve": "resolving",
+    "deps": "runtime deps",
+    "packages": "model package",
+    "weights": "weights",
+    "init": "initializing",
+}
+
+
+@dataclass
+class PhaseState:
+    name: str
+    status: PhaseStatus = "pending"
+    message: str = ""
+    fraction: float | None = None
+
+
+class ProgressController:
+    r"""Phase-keyed progress UI shared by CLI, HTTP, and Python entry points."""
+
+    def __init__(
+        self,
+        mode: str = "auto",
+        phases: tuple[str, ...] = PHASES,
+        sink: Callable[[dict[str, Any]], None] | None = None,
+    ) -> None:
+        self.mode = _resolve_mode(mode)
+        self.phases = {p: PhaseState(p) for p in phases}
+        self._live: Any = None
+        self._console: Any = None
+        self._sink = sink
+
+    def __enter__(self) -> "ProgressController":
+        if self.mode == "tty":
+            try:
+                from rich.console import Console
+                from rich.live import Live
+
+                self._console = Console()
+                self._live = Live(
+                    self._render(),
+                    console=self._console,
+                    refresh_per_second=10,
+                    transient=False,
+                )
+                self._live.__enter__()
+            except ImportError:
+                self.mode = "plain"
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._live is not None:
+            self._live.update(self._render(), refresh=True)
+            self._live.__exit__(exc_type, exc, tb)
+
+    def event(
+        self,
+        phase: str,
+        status: PhaseStatus,
+        message: str = "",
+        fraction: float | None = None,
+    ) -> None:
+        if phase not in self.phases:
+            return
+        ps = self.phases[phase]
+        ps.status = status
+        ps.message = message
+        ps.fraction = fraction
+
+        if self._sink is not None:
+            self._sink({"phase": phase, "status": status, "message": message, "fraction": fraction})
+
+        if self.mode == "tty" and self._live is not None:
+            self._live.update(self._render())
+        elif self.mode == "plain":
+            glyph = {
+                "running": "▸",
+                "done": "✓",
+                "skipped": "·",
+                "failed": "✗",
+            }.get(status)
+            if glyph is not None:
+                print(f"{glyph} {_LABELS.get(phase, phase):<15s} {message}", flush=True)
+        elif self.mode == "json":
+            print(
+                _json.dumps(
+                    {
+                        "phase": phase,
+                        "status": status,
+                        "message": message,
+                        "fraction": fraction,
+                    }
+                ),
+                flush=True,
+            )
+        # mode == "sink" or "quiet": sink-only (or silent)
+
+    def finalize(self, success: bool, summary: str = "") -> None:
+        if self.mode == "tty" and self._console is not None:
+            from rich.text import Text
+
+            mark = Text("✓ ready", style="bold green") if success else Text("✗ failed", style="bold red")
+            if summary:
+                self._console.print(mark, Text(f"  {summary}", style="dim"))
+            else:
+                self._console.print(mark)
+        elif self.mode == "plain":
+            print(("✓ ready " if success else "✗ failed ") + summary, flush=True)
+        elif self.mode == "json":
+            print(_json.dumps({"phase": "ready" if success else "failed", "message": summary}), flush=True)
+
+    def _render(self):
+        from rich.table import Table
+        from rich.text import Text
+
+        t = Table(show_header=False, show_edge=False, box=None, padding=(0, 1, 0, 0))
+        t.add_column(width=2, justify="center")
+        t.add_column(width=15)
+        t.add_column()
+        for name, ps in self.phases.items():
+            glyph = _glyph(ps.status)
+            label = Text(_LABELS.get(name, name), style="bold" if ps.status == "running" else "dim")
+            body = ps.message
+            if ps.fraction is not None:
+                bar = _bar(ps.fraction)
+                body = f"{ps.message}  {bar} {int(ps.fraction * 100):3d}%"
+            t.add_row(glyph, label, Text(body))
+        return t
+
+
+def _resolve_mode(mode: str) -> str:
+    if os.environ.get("WORLDKERNELS_QUIET"):
+        return "quiet"
+    if mode == "auto":
+        return "plain"
+    return mode
+
+
+def _glyph(status: PhaseStatus):
+    from rich.text import Text
+
+    return {
+        "pending": Text("·", style="dim"),
+        "running": Text("▸", style="cyan bold"),
+        "done": Text("✓", style="green"),
+        "skipped": Text("·", style="dim"),
+        "failed": Text("✗", style="red bold"),
+    }.get(status, Text("·", style="dim"))
+
+
+def _bar(frac: float, width: int = 16) -> str:
+    frac = max(0.0, min(1.0, frac))
+    filled = int(frac * width)
+    return "█" * filled + "░" * (width - filled)

--- a/worldkernels/bootstrap/progress.py
+++ b/worldkernels/bootstrap/progress.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import json as _json
 import logging
 import os
-import sys
 from dataclasses import dataclass
 from typing import Any, Callable, Literal
 
@@ -122,7 +121,11 @@ class ProgressController:
         if self.mode == "tty" and self._console is not None:
             from rich.text import Text
 
-            mark = Text("✓ ready", style="bold green") if success else Text("✗ failed", style="bold red")
+            mark = (
+                Text("✓ ready", style="bold green")
+                if success
+                else Text("✗ failed", style="bold red")
+            )
             if summary:
                 self._console.print(mark, Text(f"  {summary}", style="dim"))
             else:
@@ -130,7 +133,8 @@ class ProgressController:
         elif self.mode == "plain":
             print(("✓ ready " if success else "✗ failed ") + summary, flush=True)
         elif self.mode == "json":
-            print(_json.dumps({"phase": "ready" if success else "failed", "message": summary}), flush=True)
+            event = {"phase": "ready" if success else "failed", "message": summary}
+            print(_json.dumps(event), flush=True)
 
     def _render(self):
         from rich.table import Table

--- a/worldkernels/bootstrap/resolve.py
+++ b/worldkernels/bootstrap/resolve.py
@@ -58,10 +58,25 @@ def resolve(ref: str, variant: str | None = None, ckpt_path: str | None = None) 
         if card is not None:
             return _from_card(card, ref, variant, ckpt_path)
 
+    if _registered_in_worlds(ref):
+        from worldkernels.worlds.hub import ModelCard
+
+        synthetic = ModelCard(adapter=ref, description=f"registry-only adapter: {ref}")
+        return _from_card(synthetic, ref, variant, ckpt_path)
+
     raise ModelNotFoundError(
         f"could not resolve model '{ref}'. "
         f"Try a registered alias (`worldkernels models`) or an HF repo id (org/name)."
     )
+
+
+def _registered_in_worlds(name: str) -> bool:
+    try:
+        from worldkernels.worlds.registry import _REGISTRY
+
+        return name in _REGISTRY
+    except Exception:
+        return False
 
 
 def _from_card(

--- a/worldkernels/bootstrap/resolve.py
+++ b/worldkernels/bootstrap/resolve.py
@@ -1,0 +1,104 @@
+r"""Resolve a user-facing model reference to (ModelCard, variant, ckpt_path)."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from worldkernels.bootstrap.errors import ModelNotFoundError
+
+if TYPE_CHECKING:
+    from worldkernels.worlds.hub import ModelCard
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class ResolvedRef:
+    card: "ModelCard"
+    name: str
+    variant: str | None = None
+    ckpt_path: str | None = None
+
+
+def resolve(ref: str, variant: str | None = None, ckpt_path: str | None = None) -> ResolvedRef:
+    r"""Resolve a CLI/HTTP model reference.
+
+    Resolution order:
+    1. Local file/dir path (if it exists on disk).
+    2. Literal hub key.
+    3. Variant-suffix split (``name:variant`` or ``name@variant``).
+    4. HF URL strip → repo ID lookup.
+    5. Bare HF repo ID (``org/repo``) — looked up in hub, else a synthetic card.
+    """
+    from worldkernels.worlds.hub import get_model_card, infer_card_from_hf
+
+    if ckpt_path is None and _looks_like_path(ref):
+        return _local_ref(ref, variant)
+
+    url_stripped = _strip_hf_url(ref)
+    if url_stripped is not None:
+        ref = url_stripped
+
+    card = get_model_card(ref)
+    if card is not None:
+        return _from_card(card, ref, variant, ckpt_path)
+
+    for sep in (":", "@"):
+        if sep in ref:
+            base, _, suf = ref.rpartition(sep)
+            base_card = get_model_card(base)
+            if base_card is not None:
+                return _from_card(base_card, base, variant or suf, ckpt_path)
+
+    if "/" in ref:
+        card = infer_card_from_hf(ref)
+        if card is not None:
+            return _from_card(card, ref, variant, ckpt_path)
+
+    raise ModelNotFoundError(
+        f"could not resolve model '{ref}'. "
+        f"Try a registered alias (`worldkernels models`) or an HF repo id (org/name)."
+    )
+
+
+def _from_card(
+    card: "ModelCard",
+    name: str,
+    variant: str | None,
+    ckpt_path: str | None,
+) -> ResolvedRef:
+    if variant is None and card.default_kwargs.get("variant"):
+        variant = card.default_kwargs["variant"]
+    return ResolvedRef(card=card, name=name, variant=variant, ckpt_path=ckpt_path)
+
+
+def _local_ref(ref: str, variant: str | None) -> ResolvedRef:
+    from worldkernels.worlds.hub import ModelCard
+
+    path = Path(ref).expanduser().resolve()
+    suf = path.suffix.lower()
+    if suf in {".pt", ".bin", ".safetensors"} or (path.is_dir() and (path / "config.py").exists()):
+        adapter = "dreamdojo"
+    else:
+        adapter = "dreamdojo"
+    card = ModelCard(adapter=adapter, description=f"local checkpoint: {path}")
+    return ResolvedRef(card=card, name=path.name, variant=variant, ckpt_path=str(path))
+
+
+def _looks_like_path(ref: str) -> bool:
+    if ref.startswith(("./", "../", "/", "~")):
+        return True
+    p = Path(ref).expanduser()
+    return p.exists()
+
+
+def _strip_hf_url(ref: str) -> str | None:
+    prefixes = ("https://huggingface.co/", "http://huggingface.co/", "hf://")
+    for pre in prefixes:
+        if ref.startswith(pre):
+            tail = ref[len(pre) :].split("?")[0].split("#")[0].rstrip("/")
+            return tail
+    return None

--- a/worldkernels/bootstrap/weights.py
+++ b/worldkernels/bootstrap/weights.py
@@ -1,0 +1,71 @@
+r"""Checkpoint provisioning: HF snapshot_download or local path passthrough."""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from worldkernels.bootstrap.errors import AuthRequiredError, FetchDisabledError
+
+if TYPE_CHECKING:
+    from worldkernels.bootstrap.progress import ProgressController
+    from worldkernels.worlds.hub import ModelCard
+
+log = logging.getLogger(__name__)
+
+
+def provision_weights(
+    card: "ModelCard",
+    variant: str | None = None,
+    ckpt_path: str | None = None,
+    progress: "ProgressController | None" = None,
+    allow_fetch: bool = True,
+) -> str | None:
+    if ckpt_path is not None:
+        p = Path(ckpt_path).expanduser()
+        if not p.exists():
+            raise FileNotFoundError(f"checkpoint path does not exist: {p}")
+        if progress is not None:
+            progress.event("weights", "done", f"local: {p}")
+        return str(p)
+
+    if card.hf_repo is None:
+        if progress is not None:
+            progress.event("weights", "skipped", "no hf repo declared")
+        return None
+
+    if not allow_fetch or os.environ.get("WORLDKERNELS_NO_AUTO_INSTALL"):
+        raise FetchDisabledError(
+            f"missing weights for {card.hf_repo}",
+            f"run `worldkernels pull {card.hf_repo}` or pass --ckpt-path",
+        )
+
+    if progress is not None:
+        progress.event("weights", "running", f"{card.hf_repo} · {variant or ''}".strip(" ·"))
+
+    try:
+        from huggingface_hub import snapshot_download
+        from huggingface_hub.errors import GatedRepoError, RepositoryNotFoundError
+    except ImportError as exc:
+        raise RuntimeError("huggingface_hub is required") from exc
+
+    allow_patterns = card.allow_patterns
+    if variant and card.variant_pattern:
+        allow_patterns = [p.format(variant=variant) for p in card.variant_pattern]
+
+    try:
+        local_dir = snapshot_download(
+            card.hf_repo,
+            allow_patterns=allow_patterns,
+            repo_type="model",
+        )
+    except GatedRepoError as exc:
+        raise AuthRequiredError(card.hf_repo) from exc
+    except RepositoryNotFoundError as exc:
+        raise RuntimeError(f"HF repo not found: {card.hf_repo}") from exc
+
+    if progress is not None:
+        progress.event("weights", "done", f"{card.hf_repo}")
+    return local_dir

--- a/worldkernels/cli/bench.py
+++ b/worldkernels/cli/bench.py
@@ -18,9 +18,13 @@ def bench_env(
     height: int = 64,
     width: int = 64,
     num_sessions: int = 1,
+    profile: str | None = None,
 ) -> Generator[tuple[WorldEngine, list[Session]], None, None]:
     r"""Shared setup/teardown for benchmark commands."""
-    wk = WorldEngine(device=device, max_sessions=max_sessions)
+    if profile is not None:
+        wk = WorldEngine(profile, device=device, max_sessions=max_sessions)
+    else:
+        wk = WorldEngine(device=device, max_sessions=max_sessions)
     wk.load_model(world)
     world_key = world.split("/")[-1]
     config = WorldConfig(height=height, width=width, frames_per_step=1)
@@ -33,8 +37,10 @@ def bench_env(
         wk.shutdown()
 
 
-def run_latency(world: str, steps: int, height: int, width: int, device: str) -> None:
-    with bench_env(world, device, height=height, width=width) as (_, sessions):
+def run_latency(
+    world: str, steps: int, height: int, width: int, device: str, profile: str | None = None
+) -> None:
+    with bench_env(world, device, height=height, width=width, profile=profile) as (_, sessions):
         session = sessions[0]
         latencies: list[float] = []
         for _ in range(steps):
@@ -53,7 +59,13 @@ def run_latency(world: str, steps: int, height: int, width: int, device: str) ->
 
 
 def run_throughput(
-    world: str, num_sessions: int, steps: int, height: int, width: int, device: str
+    world: str,
+    num_sessions: int,
+    steps: int,
+    height: int,
+    width: int,
+    device: str,
+    profile: str | None = None,
 ) -> None:
     with bench_env(
         world,
@@ -62,6 +74,7 @@ def run_throughput(
         height=height,
         width=width,
         num_sessions=num_sessions,
+        profile=profile,
     ) as (_, sessions):
         t0 = time.perf_counter()
         for _ in range(steps):

--- a/worldkernels/cli/collect_env.py
+++ b/worldkernels/cli/collect_env.py
@@ -1,0 +1,94 @@
+r"""Collect environment info: GPU, deps, plugins, hub, local cache, isolated envs.
+
+Mirrors `vllm collect-env` / `python -m torch.utils.collect_env`: prints what's
+useful when filing a bug report or sanity-checking a new install.
+"""
+
+from __future__ import annotations
+
+import importlib
+import shutil
+
+
+def run_collect_env() -> None:
+    print("worldkernels collect-env\n")
+
+    print("Python & libs:")
+    _check_import("torch", required=True)
+    _check_import("huggingface_hub", required=True)
+    _check_import("fastapi", required=True)
+    _check_import("rich", required=False)
+    _check_import("transformers", required=False)
+    _check_import("diffusers", required=False)
+    _check_import("flash_attn", required=False)
+
+    print("\nGPU:")
+    try:
+        import torch
+
+        if torch.cuda.is_available():
+            for i in range(torch.cuda.device_count()):
+                name = torch.cuda.get_device_name(i)
+                cap = torch.cuda.get_device_capability(i)
+                free, total = torch.cuda.mem_get_info(i)
+                gb_free = free / (1024**3)
+                gb_total = total / (1024**3)
+                print(f"  cuda:{i}  {name}  sm_{cap[0]}{cap[1]}  {gb_free:.1f}/{gb_total:.1f} GB free")
+        else:
+            print("  no cuda available")
+    except Exception as exc:
+        print(f"  torch check failed: {exc}")
+
+    print("\nTools:")
+    print(f"  git: {'found' if shutil.which('git') else 'MISSING'}")
+    print(f"  uv:  {'found' if shutil.which('uv') else 'MISSING'}")
+
+    print("\nHub (registered models):")
+    try:
+        from worldkernels.worlds.hub import list_models
+
+        for name, card in sorted(list_models().items()):
+            print(f"  {name:32s}  adapter={card.adapter}")
+    except Exception as exc:
+        print(f"  hub load failed: {exc}")
+
+    print("\nLocal cache:")
+    try:
+        from worldkernels.bootstrap import cache
+
+        manifests = cache.list_manifests()
+        print(f"  home: {cache.home()}")
+        print(f"  cached models: {len(manifests)}")
+        for m in manifests:
+            v = f":{m.variant}" if m.variant else ""
+            print(f"    {m.model_id}{v}")
+    except Exception as exc:
+        print(f"  cache scan failed: {exc}")
+
+    print("\nIsolated envs:")
+    try:
+        from worldkernels.bootstrap import cache
+        from worldkernels.runtime import envs
+
+        envs_root = envs.envs_dir()
+        if envs_root.exists():
+            children = [p for p in envs_root.iterdir() if p.is_dir()]
+            print(f"  root: {envs_root}")
+            print(f"  count: {len(children)}")
+            for env_dir in children:
+                size_mb = cache.directory_size_bytes(env_dir) / (1024 * 1024)
+                print(f"    {env_dir.name}  {size_mb:.0f} MB")
+        else:
+            print("  (none)")
+    except Exception as exc:
+        print(f"  env scan failed: {exc}")
+
+
+def _check_import(name: str, required: bool = False) -> None:
+    try:
+        mod = importlib.import_module(name)
+        ver = getattr(mod, "__version__", "?")
+        print(f"  {name:18s} {ver}")
+    except ImportError:
+        tag = "MISSING" if required else "(optional, not installed)"
+        print(f"  {name:18s} {tag}")

--- a/worldkernels/cli/collect_env.py
+++ b/worldkernels/cli/collect_env.py
@@ -33,7 +33,10 @@ def run_collect_env() -> None:
                 free, total = torch.cuda.mem_get_info(i)
                 gb_free = free / (1024**3)
                 gb_total = total / (1024**3)
-                print(f"  cuda:{i}  {name}  sm_{cap[0]}{cap[1]}  {gb_free:.1f}/{gb_total:.1f} GB free")
+                print(
+                    f"  cuda:{i}  {name}  sm_{cap[0]}{cap[1]}  "
+                    f"{gb_free:.1f}/{gb_total:.1f} GB free"
+                )
         else:
             print("  no cuda available")
     except Exception as exc:

--- a/worldkernels/cli/collect_env.py
+++ b/worldkernels/cli/collect_env.py
@@ -34,8 +34,7 @@ def run_collect_env() -> None:
                 gb_free = free / (1024**3)
                 gb_total = total / (1024**3)
                 print(
-                    f"  cuda:{i}  {name}  sm_{cap[0]}{cap[1]}  "
-                    f"{gb_free:.1f}/{gb_total:.1f} GB free"
+                    f"  cuda:{i}  {name}  sm_{cap[0]}{cap[1]}  {gb_free:.1f}/{gb_total:.1f} GB free"
                 )
         else:
             print("  no cuda available")

--- a/worldkernels/cli/collect_env.py
+++ b/worldkernels/cli/collect_env.py
@@ -65,6 +65,19 @@ def run_collect_env() -> None:
     except Exception as exc:
         print(f"  cache scan failed: {exc}")
 
+    print("\nRuntime config (defaults; WK_* env applied):")
+    try:
+        from worldkernels.config.profiles import resolve_runtime_config
+        from worldkernels.config.runtime import ALL_TOGGLE_FIELDS
+
+        cfg, sources = resolve_runtime_config()
+        for f in ALL_TOGGLE_FIELDS:
+            src = sources.get(f, "default")
+            tag = "" if src == "default" else f"  ({src})"
+            print(f"  {f:20s} {getattr(cfg, f)}{tag}")
+    except Exception as exc:
+        print(f"  runtime config load failed: {exc}")
+
     print("\nIsolated envs:")
     try:
         from worldkernels.bootstrap import cache

--- a/worldkernels/cli/config_cmd.py
+++ b/worldkernels/cli/config_cmd.py
@@ -1,0 +1,29 @@
+r"""`worldkernels config-show` — print the resolved runtime config + source of each flag."""
+
+from __future__ import annotations
+
+
+def run_config_show(profile: str | None = None, as_json: bool = False) -> None:
+    from worldkernels.config.profiles import resolve_runtime_config
+    from worldkernels.config.runtime import ALL_TOGGLE_FIELDS
+
+    cfg, sources = resolve_runtime_config(profile=profile)
+    fields = ["device", "max_sessions", *ALL_TOGGLE_FIELDS]
+
+    if as_json:
+        import json
+
+        data = {f: {"value": getattr(cfg, f), "source": sources.get(f, "default")} for f in fields}
+        print(json.dumps(data, indent=2))
+        return
+
+    print(f"{'flag':22s} {'value':10s} source")
+    for f in fields:
+        print(f"{f:22s} {str(getattr(cfg, f)):10s} {sources.get(f, 'default')}")
+
+    print()
+    print(
+        f"[nested] scheduler.max_batch_size={cfg.scheduler.max_batch_size}  "
+        f"cache.block_frames={cfg.cache.block_frames}  "
+        f"parallel.tensor_parallel_size={cfg.parallel.tensor_parallel_size}"
+    )

--- a/worldkernels/cli/main.py
+++ b/worldkernels/cli/main.py
@@ -153,13 +153,13 @@ class Rm:
 
 
 @dataclass
-class Doctor:
-    r"""Check system: GPU, deps, plugins, hub, local cache."""
+class CollectEnv:
+    r"""Collect environment info: GPU, deps, plugins, hub, local cache, isolated envs."""
 
     def run(self) -> None:
-        from worldkernels.cli.doctor import run_doctor
+        from worldkernels.cli.collect_env import run_collect_env
 
-        run_doctor()
+        run_collect_env()
 
 
 @dataclass
@@ -254,13 +254,32 @@ class BenchProfile:
 
 
 @dataclass
-class PluginList:
+class Plugins:
     r"""List discovered entry_point plugins."""
 
     def run(self) -> None:
-        from worldkernels.cli.plugin import run_list
+        from worldkernels.cli.plugins import run_list
 
         run_list()
+
+
+BenchCommand = Union[
+    Annotated[BenchLatency, tyro.conf.subcommand("latency")],
+    Annotated[BenchThroughput, tyro.conf.subcommand("throughput")],
+    Annotated[BenchStartup, tyro.conf.subcommand("startup")],
+    Annotated[BenchVRAM, tyro.conf.subcommand("vram")],
+    Annotated[BenchProfile, tyro.conf.subcommand("profile")],
+]
+
+
+@dataclass
+class Bench:
+    r"""Benchmarks: latency, throughput, startup, vram, profile."""
+
+    cmd: BenchCommand
+
+    def run(self) -> None:
+        self.cmd.run()
 
 
 def _extra_kwargs(num_inference_steps: int | None, guidance_scale: float | None) -> dict:
@@ -279,14 +298,10 @@ Command = tyro.conf.SuppressFixed[
         Annotated[Pull, tyro.conf.subcommand("pull")],
         Annotated[Models, tyro.conf.subcommand("models")],
         Annotated[Rm, tyro.conf.subcommand("rm")],
-        Annotated[Doctor, tyro.conf.subcommand("doctor")],
+        Annotated[CollectEnv, tyro.conf.subcommand("collect-env")],
         Annotated[ModelInspect, tyro.conf.subcommand("inspect")],
-        Annotated[BenchLatency, tyro.conf.subcommand("bench:latency", prefix_name=False)],
-        Annotated[BenchThroughput, tyro.conf.subcommand("bench:throughput", prefix_name=False)],
-        Annotated[BenchStartup, tyro.conf.subcommand("bench:startup", prefix_name=False)],
-        Annotated[BenchVRAM, tyro.conf.subcommand("bench:vram", prefix_name=False)],
-        Annotated[BenchProfile, tyro.conf.subcommand("bench:profile", prefix_name=False)],
-        Annotated[PluginList, tyro.conf.subcommand("plugin:list", prefix_name=False)],
+        Annotated[Bench, tyro.conf.subcommand("bench")],
+        Annotated[Plugins, tyro.conf.subcommand("plugins")],
     ]
 ]
 

--- a/worldkernels/cli/main.py
+++ b/worldkernels/cli/main.py
@@ -244,7 +244,12 @@ class BenchThroughput:
         from worldkernels.cli.bench import run_throughput
 
         run_throughput(
-            self.world, self.sessions, self.steps, self.height, self.width, self.device,
+            self.world,
+            self.sessions,
+            self.steps,
+            self.height,
+            self.width,
+            self.device,
             profile=self.profile,
         )
 

--- a/worldkernels/cli/main.py
+++ b/worldkernels/cli/main.py
@@ -35,6 +35,7 @@ class Serve:
     device: str = "cuda"
     variant: str | None = None
     ckpt_path: str | None = None
+    profile: str | None = None
     num_inference_steps: int | None = None
     guidance_scale: float | None = None
     no_fetch: bool = False
@@ -55,6 +56,7 @@ class Serve:
             model_kwargs=_extra_kwargs(self.num_inference_steps, self.guidance_scale),
             allow_fetch=not self.no_fetch,
             quiet=self.quiet,
+            profile=self.profile,
         )
 
 
@@ -77,6 +79,7 @@ class Run:
     decode: bool = True
     variant: str | None = None
     ckpt_path: str | None = None
+    profile: str | None = None
     num_inference_steps: int | None = None
     guidance_scale: float | None = None
     prompt: str | None = None
@@ -106,6 +109,7 @@ class Run:
             model_kwargs=_extra_kwargs(self.num_inference_steps, self.guidance_scale),
             allow_fetch=not self.no_fetch,
             quiet=self.quiet,
+            profile=self.profile,
         )
 
 
@@ -160,6 +164,19 @@ class CollectEnv:
         from worldkernels.cli.collect_env import run_collect_env
 
         run_collect_env()
+
+
+@dataclass
+class ConfigShow:
+    r"""Show the resolved runtime config (component toggles) and each flag's source."""
+
+    profile: str | None = None
+    json: bool = False
+
+    def run(self) -> None:
+        from worldkernels.cli.config_cmd import run_config_show
+
+        run_config_show(self.profile, self.json)
 
 
 @dataclass
@@ -299,6 +316,7 @@ Command = tyro.conf.SuppressFixed[
         Annotated[Models, tyro.conf.subcommand("models")],
         Annotated[Rm, tyro.conf.subcommand("rm")],
         Annotated[CollectEnv, tyro.conf.subcommand("collect-env")],
+        Annotated[ConfigShow, tyro.conf.subcommand("config-show")],
         Annotated[ModelInspect, tyro.conf.subcommand("inspect")],
         Annotated[Bench, tyro.conf.subcommand("bench")],
         Annotated[Plugins, tyro.conf.subcommand("plugins")],

--- a/worldkernels/cli/main.py
+++ b/worldkernels/cli/main.py
@@ -36,6 +36,13 @@ class Serve:
     variant: str | None = None
     ckpt_path: str | None = None
     profile: str | None = None
+    set_overrides: Annotated[
+        str | None,
+        tyro.conf.arg(
+            name="set",
+            help="Comma-separated runtime overrides (e.g. teacache=off,attention_backend=sdpa).",
+        ),
+    ] = None
     num_inference_steps: int | None = None
     guidance_scale: float | None = None
     no_fetch: bool = False
@@ -57,6 +64,7 @@ class Serve:
             allow_fetch=not self.no_fetch,
             quiet=self.quiet,
             profile=self.profile,
+            overrides=_parse_set(self.set_overrides),
         )
 
 
@@ -80,6 +88,13 @@ class Run:
     variant: str | None = None
     ckpt_path: str | None = None
     profile: str | None = None
+    set_overrides: Annotated[
+        str | None,
+        tyro.conf.arg(
+            name="set",
+            help="Comma-separated runtime overrides (e.g. teacache=off,attention_backend=sdpa).",
+        ),
+    ] = None
     num_inference_steps: int | None = None
     guidance_scale: float | None = None
     prompt: str | None = None
@@ -110,6 +125,7 @@ class Run:
             allow_fetch=not self.no_fetch,
             quiet=self.quiet,
             profile=self.profile,
+            overrides=_parse_set(self.set_overrides),
         )
 
 
@@ -202,11 +218,14 @@ class BenchLatency:
     height: int = 64
     width: int = 64
     device: str = "cpu"
+    profile: str | None = None
 
     def run(self) -> None:
         from worldkernels.cli.bench import run_latency
 
-        run_latency(self.world, self.steps, self.height, self.width, self.device)
+        run_latency(
+            self.world, self.steps, self.height, self.width, self.device, profile=self.profile
+        )
 
 
 @dataclass
@@ -219,11 +238,15 @@ class BenchThroughput:
     height: int = 64
     width: int = 64
     device: str = "cpu"
+    profile: str | None = None
 
     def run(self) -> None:
         from worldkernels.cli.bench import run_throughput
 
-        run_throughput(self.world, self.sessions, self.steps, self.height, self.width, self.device)
+        run_throughput(
+            self.world, self.sessions, self.steps, self.height, self.width, self.device,
+            profile=self.profile,
+        )
 
 
 @dataclass
@@ -297,6 +320,36 @@ class Bench:
 
     def run(self) -> None:
         self.cmd.run()
+
+
+_BOOL_TRUE = {"1", "true", "yes", "on"}
+_BOOL_FALSE = {"0", "false", "no", "off"}
+
+
+def _parse_set(value: str | None) -> dict | None:
+    r"""Parse a ``--set k=v,k=v`` string into a RuntimeConfig overrides dict.
+
+    Bools accept ``on``/``off``/``true``/``false``/``1``/``0``; enums pass through
+    as strings. Validation happens in ``resolve_runtime_config``.
+    """
+    if not value:
+        return None
+    out: dict = {}
+    for pair in value.split(","):
+        if not pair.strip():
+            continue
+        if "=" not in pair:
+            raise ValueError(f"--set entry must be key=value, got {pair!r}")
+        key, val = pair.split("=", 1)
+        key, val = key.strip(), val.strip()
+        lv = val.lower()
+        if lv in _BOOL_TRUE:
+            out[key] = True
+        elif lv in _BOOL_FALSE:
+            out[key] = False
+        else:
+            out[key] = val
+    return out
 
 
 def _extra_kwargs(num_inference_steps: int | None, guidance_scale: float | None) -> dict:

--- a/worldkernels/cli/main.py
+++ b/worldkernels/cli/main.py
@@ -1,8 +1,4 @@
-r"""WorldKernels CLI.
-
-Pure schema: each dataclass defines a subcommand's flags.
-Implementations live in sibling modules.
-"""
+r"""WorldKernels CLI: vLLM-style positional verbs."""
 
 from __future__ import annotations
 
@@ -12,118 +8,153 @@ from typing import Annotated, Union
 
 import tyro
 
-# ---------------------------------------------------------------------------
-# serve
-# ---------------------------------------------------------------------------
+_PositionalModel = Annotated[
+    str,
+    tyro.conf.Positional,
+    tyro.conf.arg(help="Model: short alias, HF repo id, HF URL, or local checkpoint path."),
+]
 
 
 @dataclass
 class Serve:
-    r"""Start the WorldKernels HTTP/WebSocket server."""
+    r"""Start the WorldKernels HTTP/WebSocket server.
 
+    With a model arg, the model is bootstrapped (deps, weights) and pre-loaded;
+    without one, the server starts empty and models load on first request.
+    """
+
+    model: Annotated[
+        str | None,
+        tyro.conf.Positional,
+        tyro.conf.arg(help="Model to pre-load (optional)."),
+    ] = None
     host: str = "0.0.0.0"
     port: int = 8000
     max_sessions: int = 4
     api_key: Annotated[str | None, tyro.conf.arg(aliases=("-k",))] = None
     device: str = "cuda"
-    model: str | None = None
+    variant: str | None = None
     ckpt_path: str | None = None
-    experiment: str | None = None
     num_inference_steps: int | None = None
     guidance_scale: float | None = None
+    no_fetch: bool = False
+    quiet: Annotated[bool, tyro.conf.arg(aliases=("-q",))] = False
 
     def run(self) -> None:
         from worldkernels.cli.serve import run_serve
 
-        model_kwargs: dict = {}
-        if self.ckpt_path is not None:
-            model_kwargs["ckpt_path"] = self.ckpt_path
-        if self.experiment is not None:
-            model_kwargs["experiment"] = self.experiment
-        if self.num_inference_steps is not None:
-            model_kwargs["num_inference_steps"] = self.num_inference_steps
-        if self.guidance_scale is not None:
-            model_kwargs["guidance_scale"] = self.guidance_scale
-
         run_serve(
-            self.host,
-            self.port,
-            self.max_sessions,
-            self.api_key,
-            self.device,
-            self.model,
-            model_kwargs,
+            host=self.host,
+            port=self.port,
+            max_sessions=self.max_sessions,
+            api_key=self.api_key,
+            device=self.device,
+            model=self.model,
+            variant=self.variant,
+            ckpt_path=self.ckpt_path,
+            model_kwargs=_extra_kwargs(self.num_inference_steps, self.guidance_scale),
+            allow_fetch=not self.no_fetch,
+            quiet=self.quiet,
         )
-
-
-# ---------------------------------------------------------------------------
-# run
-# ---------------------------------------------------------------------------
 
 
 @dataclass
 class Run:
-    r"""Run a headless session: load model, step N times, optionally save frames."""
+    r"""Headless run: bootstrap a model, step N times, optionally save frames/video."""
 
-    world: str = "dummy"
+    model: _PositionalModel = "dummy"
     steps: int = 10
     action_type: str = "null"
     height: int = 480
     width: int = 848
     device: str = "cuda"
     seed: int = 0
-    output_dir: str | None = None
+    output_dir: Annotated[str | None, tyro.conf.arg(aliases=("-o",))] = None
     output_format: str = "frames"
     fps: int = 24
     video_codec: str = "libx264"
     modalities: str = "frames"
     decode: bool = True
+    variant: str | None = None
     ckpt_path: str | None = None
-    experiment: str | None = None
     num_inference_steps: int | None = None
     guidance_scale: float | None = None
     prompt: str | None = None
+    no_fetch: bool = False
+    quiet: Annotated[bool, tyro.conf.arg(aliases=("-q",))] = False
 
     def run(self) -> None:
         from worldkernels.cli.run import run_session
 
-        model_kwargs: dict = {}
-        if self.ckpt_path is not None:
-            model_kwargs["ckpt_path"] = self.ckpt_path
-        if self.experiment is not None:
-            model_kwargs["experiment"] = self.experiment
-        if self.num_inference_steps is not None:
-            model_kwargs["num_inference_steps"] = self.num_inference_steps
-        if self.guidance_scale is not None:
-            model_kwargs["guidance_scale"] = self.guidance_scale
-
         run_session(
-            self.world,
-            self.steps,
-            self.action_type,
-            self.height,
-            self.width,
-            self.device,
-            self.seed,
-            self.output_dir,
-            self.output_format,
-            self.fps,
-            self.video_codec,
-            self.modalities,
-            self.decode,
-            self.prompt,
-            model_kwargs,
+            model=self.model,
+            steps=self.steps,
+            action_type=self.action_type,
+            height=self.height,
+            width=self.width,
+            device=self.device,
+            seed=self.seed,
+            output_dir=self.output_dir,
+            output_format=self.output_format,
+            fps=self.fps,
+            video_codec=self.video_codec,
+            modalities=self.modalities,
+            decode=self.decode,
+            prompt=self.prompt,
+            variant=self.variant,
+            ckpt_path=self.ckpt_path,
+            model_kwargs=_extra_kwargs(self.num_inference_steps, self.guidance_scale),
+            allow_fetch=not self.no_fetch,
+            quiet=self.quiet,
         )
 
 
-# ---------------------------------------------------------------------------
-# doctor
-# ---------------------------------------------------------------------------
+@dataclass
+class Pull:
+    r"""Pre-fetch a model: install deps, clone packages, download weights. No server."""
+
+    model: _PositionalModel = "dummy"
+    variant: str | None = None
+    ckpt_path: str | None = None
+    quiet: Annotated[bool, tyro.conf.arg(aliases=("-q",))] = False
+
+    def run(self) -> None:
+        from worldkernels.cli.pull import run_pull
+
+        run_pull(self.model, variant=self.variant, ckpt_path=self.ckpt_path, quiet=self.quiet)
+
+
+@dataclass
+class Models:
+    r"""List models: locally cached by default, or the full hub with ``--all``."""
+
+    all: bool = False
+
+    def run(self) -> None:
+        from worldkernels.cli.pull import run_models
+
+        run_models(show_all=self.all)
+
+
+@dataclass
+class Rm:
+    r"""Remove a model from the local cache (weights + manifest)."""
+
+    model: _PositionalModel = ""
+    variant: str | None = None
+
+    def run(self) -> None:
+        if not self.model:
+            print("Error: model name is required")
+            raise SystemExit(1)
+        from worldkernels.cli.pull import run_rm
+
+        run_rm(self.model, variant=self.variant)
 
 
 @dataclass
 class Doctor:
-    r"""Check system environment: GPU, dependencies, plugins, world models."""
+    r"""Check system: GPU, deps, plugins, hub, local cache."""
 
     def run(self) -> None:
         from worldkernels.cli.doctor import run_doctor
@@ -131,89 +162,18 @@ class Doctor:
         run_doctor()
 
 
-# ---------------------------------------------------------------------------
-# model:*
-# ---------------------------------------------------------------------------
-
-
-@dataclass
-class ModelList:
-    r"""List registered world models."""
-
-    verbose: Annotated[bool, tyro.conf.arg(aliases=("-v",))] = False
-
-    def run(self) -> None:
-        from worldkernels.cli.model import run_list
-
-        run_list(self.verbose)
-
-
 @dataclass
 class ModelInspect:
     r"""Show model metadata: transition mode, VRAM estimate, capabilities."""
 
-    model_id: str = "dummy"
+    model: _PositionalModel = "dummy"
     device: str = "cpu"
     config_json: str | None = None
 
     def run(self) -> None:
         from worldkernels.cli.model import run_inspect
 
-        run_inspect(self.model_id, self.device, self.config_json)
-
-
-@dataclass
-class ModelDownload:
-    r"""Download a model from HuggingFace Hub."""
-
-    model_id: str = ""
-    revision: str | None = None
-    cache_dir: str | None = None
-
-    def run(self) -> None:
-        if not self.model_id:
-            print("Error: --model-id is required")
-            raise SystemExit(1)
-        from worldkernels.cli.model import run_download
-
-        run_download(self.model_id, self.revision, self.cache_dir)
-
-
-@dataclass
-class ModelRemove:
-    r"""Remove a model from the HuggingFace cache."""
-
-    model_id: str = ""
-
-    def run(self) -> None:
-        if not self.model_id:
-            print("Error: --model-id is required")
-            raise SystemExit(1)
-        from worldkernels.cli.model import run_remove
-
-        run_remove(self.model_id)
-
-
-@dataclass
-class ModelExport:
-    r"""Export a model to TensorRT or ONNX format."""
-
-    model_id: str = "dummy"
-    fmt: str = "tensorrt"
-    output: str | None = None
-    height: int = 480
-    width: int = 848
-    device: str = "cuda"
-
-    def run(self) -> None:
-        from worldkernels.cli.model import run_export
-
-        run_export(self.model_id, self.fmt, self.output, self.height, self.width, self.device)
-
-
-# ---------------------------------------------------------------------------
-# bench:*
-# ---------------------------------------------------------------------------
+        run_inspect(self.model, self.device, self.config_json)
 
 
 @dataclass
@@ -293,11 +253,6 @@ class BenchProfile:
         run_profile(self.world, self.steps, self.height, self.width, self.device, self.output)
 
 
-# ---------------------------------------------------------------------------
-# plugin:*
-# ---------------------------------------------------------------------------
-
-
 @dataclass
 class PluginList:
     r"""List discovered entry_point plugins."""
@@ -308,21 +263,24 @@ class PluginList:
         run_list()
 
 
-# ---------------------------------------------------------------------------
-# Command union
-# ---------------------------------------------------------------------------
+def _extra_kwargs(num_inference_steps: int | None, guidance_scale: float | None) -> dict:
+    out: dict = {}
+    if num_inference_steps is not None:
+        out["num_inference_steps"] = num_inference_steps
+    if guidance_scale is not None:
+        out["guidance_scale"] = guidance_scale
+    return out
 
 
 Command = tyro.conf.SuppressFixed[
     Union[
         Annotated[Serve, tyro.conf.subcommand("serve")],
         Annotated[Run, tyro.conf.subcommand("run")],
+        Annotated[Pull, tyro.conf.subcommand("pull")],
+        Annotated[Models, tyro.conf.subcommand("models")],
+        Annotated[Rm, tyro.conf.subcommand("rm")],
         Annotated[Doctor, tyro.conf.subcommand("doctor")],
-        Annotated[ModelList, tyro.conf.subcommand("model:list", prefix_name=False)],
-        Annotated[ModelInspect, tyro.conf.subcommand("model:inspect", prefix_name=False)],
-        Annotated[ModelDownload, tyro.conf.subcommand("model:download", prefix_name=False)],
-        Annotated[ModelRemove, tyro.conf.subcommand("model:remove", prefix_name=False)],
-        Annotated[ModelExport, tyro.conf.subcommand("model:export", prefix_name=False)],
+        Annotated[ModelInspect, tyro.conf.subcommand("inspect")],
         Annotated[BenchLatency, tyro.conf.subcommand("bench:latency", prefix_name=False)],
         Annotated[BenchThroughput, tyro.conf.subcommand("bench:throughput", prefix_name=False)],
         Annotated[BenchStartup, tyro.conf.subcommand("bench:startup", prefix_name=False)],

--- a/worldkernels/cli/plugins.py
+++ b/worldkernels/cli/plugins.py
@@ -1,0 +1,21 @@
+r"""List entry_points plugins discovered for worldkernels."""
+
+from __future__ import annotations
+
+
+def run_list() -> None:
+    from importlib.metadata import entry_points
+
+    eps = entry_points()
+    groups = ("worldkernels.worlds", "worldkernels.pipelines")
+
+    for group in groups:
+        if hasattr(eps, "select"):
+            items = list(eps.select(group=group))
+        else:
+            items = list(eps.get(group, []))
+        print(f"[{group}]")
+        if not items:
+            print("  (none)")
+        for ep in items:
+            print(f"  {ep.name:24s}  {ep.value}")

--- a/worldkernels/cli/pull.py
+++ b/worldkernels/cli/pull.py
@@ -1,0 +1,85 @@
+r"""Pull / models / rm command implementations."""
+
+from __future__ import annotations
+
+import os
+
+
+def run_pull(model: str, variant: str | None = None, ckpt_path: str | None = None, quiet: bool = False) -> None:
+    from worldkernels.bootstrap import ProgressController, prepare
+
+    if quiet:
+        os.environ["WORLDKERNELS_QUIET"] = "1"
+
+    with ProgressController(mode="quiet" if quiet else "plain") as progress:
+        prepared = prepare(model, variant=variant, ckpt_path=ckpt_path, progress=progress)
+        progress.finalize(success=True, summary=f"cached {prepared.alias}")
+
+
+def run_models(show_all: bool = False) -> None:
+    from worldkernels.bootstrap import cache
+
+    if show_all:
+        from worldkernels.worlds.hub import list_models
+
+        hub = list_models()
+        print("Available models (hub):")
+        for name, card in sorted(hub.items()):
+            desc = f"  {card.description}" if card.description else ""
+            print(f"  {name:32s}{desc}")
+        return
+
+    manifests = cache.list_manifests()
+    if not manifests:
+        print("No models cached locally. Use `worldkernels pull <model>` or `worldkernels models --all`.")
+        return
+
+    print(f"Local models (cached under {cache.home()}):")
+    for m in sorted(manifests, key=lambda x: x.model_id):
+        variant_str = f":{m.variant}" if m.variant else ""
+        size_str = ""
+        if m.hf_repo:
+            sz = cache.hf_cache_size_bytes(m.hf_repo)
+            if sz:
+                size_str = f"  {_human(sz)}"
+        print(f"  {m.model_id}{variant_str:20s}  adapter={m.adapter}{size_str}")
+
+
+def run_rm(model: str, variant: str | None = None) -> None:
+    from huggingface_hub import scan_cache_dir
+
+    from worldkernels.bootstrap import cache
+    from worldkernels.runtime import envs
+    from worldkernels.worlds.hub import get_model_card
+
+    removed_manifest = cache.remove_manifest(model, variant)
+    removed_env = envs.remove_env(model)
+
+    card = get_model_card(model)
+    hf_repo = card.hf_repo if card and card.hf_repo else (model if "/" in model else None)
+
+    if hf_repo:
+        try:
+            info = scan_cache_dir()
+            for repo in info.repos:
+                if repo.repo_id == hf_repo:
+                    for rev in repo.revisions:
+                        info.delete_revisions(rev.commit_hash).execute()
+                        print(f"removed {hf_repo} ({rev.commit_hash[:12]})")
+        except Exception as exc:
+            print(f"warning: could not scan HF cache: {exc}")
+
+    if removed_manifest:
+        print(f"removed manifest: {model}{':' + variant if variant else ''}")
+    if removed_env:
+        print(f"removed isolated env: {model}")
+    if not (removed_manifest or removed_env or hf_repo):
+        print(f"nothing to remove for '{model}'")
+
+
+def _human(b: int) -> str:
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if b < 1024:
+            return f"{b:.1f}{unit}"
+        b /= 1024
+    return f"{b:.1f}PB"

--- a/worldkernels/cli/pull.py
+++ b/worldkernels/cli/pull.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import os
 
 
-def run_pull(model: str, variant: str | None = None, ckpt_path: str | None = None, quiet: bool = False) -> None:
+def run_pull(
+    model: str,
+    variant: str | None = None,
+    ckpt_path: str | None = None,
+    quiet: bool = False,
+) -> None:
     from worldkernels.bootstrap import ProgressController, prepare
 
     if quiet:
@@ -31,7 +36,10 @@ def run_models(show_all: bool = False) -> None:
 
     manifests = cache.list_manifests()
     if not manifests:
-        print("No models cached locally. Use `worldkernels pull <model>` or `worldkernels models --all`.")
+        print(
+            "No models cached locally. "
+            "Use `worldkernels pull <model>` or `worldkernels models --all`."
+        )
         return
 
     print(f"Local models (cached under {cache.home()}):")

--- a/worldkernels/cli/pull.py
+++ b/worldkernels/cli/pull.py
@@ -86,8 +86,9 @@ def run_rm(model: str, variant: str | None = None) -> None:
 
 
 def _human(b: int) -> str:
+    size = float(b)
     for unit in ("B", "KB", "MB", "GB", "TB"):
-        if b < 1024:
-            return f"{b:.1f}{unit}"
-        b /= 1024
-    return f"{b:.1f}PB"
+        if size < 1024:
+            return f"{size:.1f}{unit}"
+        size /= 1024
+    return f"{size:.1f}PB"

--- a/worldkernels/cli/run.py
+++ b/worldkernels/cli/run.py
@@ -27,6 +27,7 @@ def run_session(
     model_kwargs: dict[str, Any] | None = None,
     allow_fetch: bool = True,
     quiet: bool = False,
+    profile: str | None = None,
 ) -> None:
     from worldkernels import Action, WorldConfig, WorldEngine
     from worldkernels.bootstrap import ProgressController
@@ -38,7 +39,7 @@ def run_session(
     if output_format not in valid_formats:
         raise ValueError(f"--output-format must be one of {valid_formats}, got '{output_format}'")
 
-    wk = WorldEngine(device=device)
+    wk = WorldEngine(profile, device=device) if profile else WorldEngine(device=device)
     with ProgressController(mode="quiet" if quiet else "plain") as progress:
         wk.load_model(
             model,

--- a/worldkernels/cli/run.py
+++ b/worldkernels/cli/run.py
@@ -1,13 +1,14 @@
-r"""Headless session runner — load model, step N times, optionally save frames/video."""
+r"""Headless run: bootstrap model, step N times, optionally save frames/video."""
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 from typing import Any
 
 
 def run_session(
-    world: str,
+    model: str,
     steps: int = 10,
     action_type: str = "null",
     height: int = 480,
@@ -21,18 +22,35 @@ def run_session(
     modalities: str = "frames",
     decode: bool = True,
     prompt: str | None = None,
+    variant: str | None = None,
+    ckpt_path: str | None = None,
     model_kwargs: dict[str, Any] | None = None,
+    allow_fetch: bool = True,
+    quiet: bool = False,
 ) -> None:
     from worldkernels import Action, WorldConfig, WorldEngine
+    from worldkernels.bootstrap import ProgressController
+
+    if quiet:
+        os.environ["WORLDKERNELS_QUIET"] = "1"
 
     valid_formats = ("frames", "video", "both")
     if output_format not in valid_formats:
         raise ValueError(f"--output-format must be one of {valid_formats}, got '{output_format}'")
 
     wk = WorldEngine(device=device)
-    world_key = world.split("/")[-1]
-    wk.load_model(world, **(model_kwargs or {}))
+    with ProgressController(mode="quiet" if quiet else "plain") as progress:
+        wk.load_model(
+            model,
+            variant=variant,
+            ckpt_path=ckpt_path,
+            progress=progress,
+            allow_fetch=allow_fetch,
+            **(model_kwargs or {}),
+        )
+        progress.finalize(success=True, summary=f"model={model}")
 
+    world_key = next(iter(wk.list_worlds()))
     mods = [m.strip() for m in modalities.split(",")]
     cfg = WorldConfig(height=height, width=width, initial_prompt=prompt or "")
     session = wk.create_session(world_key, config=cfg, seed=seed)
@@ -44,17 +62,13 @@ def run_session(
     save_frames = output_format in ("frames", "both")
     save_video = output_format in ("video", "both")
 
-    print(f"Running {steps} steps on '{world}' ({height}x{width}, device={device})")
+    print(f"Running {steps} steps on '{world_key}' ({height}x{width}, device={device})")
 
     frame_counter = 0
     collected_frames: list[Any] = []
 
     for i in range(steps):
-        obs = session.step(
-            Action(action_type, {}),
-            modalities=mods,
-            decode=decode,
-        )
+        obs = session.step(Action(action_type, {}), modalities=mods, decode=decode)
         print(f"  step {i:4d}  time={obs.generation_time_ms:.1f}ms", end="")
 
         if out and obs.frames is not None:

--- a/worldkernels/cli/run.py
+++ b/worldkernels/cli/run.py
@@ -28,9 +28,11 @@ def run_session(
     allow_fetch: bool = True,
     quiet: bool = False,
     profile: str | None = None,
+    overrides: dict | None = None,
 ) -> None:
     from worldkernels import Action, WorldConfig, WorldEngine
     from worldkernels.bootstrap import ProgressController
+    from worldkernels.config import resolve_runtime_config
 
     if quiet:
         os.environ["WORLDKERNELS_QUIET"] = "1"
@@ -39,7 +41,8 @@ def run_session(
     if output_format not in valid_formats:
         raise ValueError(f"--output-format must be one of {valid_formats}, got '{output_format}'")
 
-    wk = WorldEngine(profile, device=device) if profile else WorldEngine(device=device)
+    runtime_config, _ = resolve_runtime_config(profile=profile, cli_overrides=overrides)
+    wk = WorldEngine(runtime_config, device=device)
     with ProgressController(mode="quiet" if quiet else "plain") as progress:
         wk.load_model(
             model,

--- a/worldkernels/cli/serve.py
+++ b/worldkernels/cli/serve.py
@@ -18,18 +18,21 @@ def run_serve(
     model_kwargs: dict[str, Any] | None = None,
     allow_fetch: bool = True,
     quiet: bool = False,
+    profile: str | None = None,
 ) -> None:
     import uvicorn
 
     from worldkernels.bootstrap import ProgressController
+    from worldkernels.config import resolve_runtime_config
     from worldkernels.core.config import ServerConfig
     from worldkernels.serving.server import create_app
 
     if quiet:
         os.environ["WORLDKERNELS_QUIET"] = "1"
 
+    runtime_config, _ = resolve_runtime_config(profile=profile)
     cfg = ServerConfig(host=host, port=port, max_sessions=max_sessions, api_key=api_key)
-    app = create_app(cfg, device=device)
+    app = create_app(cfg, device=device, runtime_config=runtime_config)
 
     if model is not None:
         from worldkernels.engine import WorldEngine

--- a/worldkernels/cli/serve.py
+++ b/worldkernels/cli/serve.py
@@ -19,6 +19,7 @@ def run_serve(
     allow_fetch: bool = True,
     quiet: bool = False,
     profile: str | None = None,
+    overrides: dict | None = None,
 ) -> None:
     import uvicorn
 
@@ -30,7 +31,7 @@ def run_serve(
     if quiet:
         os.environ["WORLDKERNELS_QUIET"] = "1"
 
-    runtime_config, _ = resolve_runtime_config(profile=profile)
+    runtime_config, _ = resolve_runtime_config(profile=profile, cli_overrides=overrides)
     cfg = ServerConfig(host=host, port=port, max_sessions=max_sessions, api_key=api_key)
     app = create_app(cfg, device=device, runtime_config=runtime_config)
 

--- a/worldkernels/cli/serve.py
+++ b/worldkernels/cli/serve.py
@@ -1,7 +1,8 @@
-r"""Serve command implementation."""
+r"""Serve command: bootstrap a model and start FastAPI."""
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 
@@ -12,27 +13,38 @@ def run_serve(
     api_key: str | None,
     device: str,
     model: str | None = None,
+    variant: str | None = None,
+    ckpt_path: str | None = None,
     model_kwargs: dict[str, Any] | None = None,
+    allow_fetch: bool = True,
+    quiet: bool = False,
 ) -> None:
     import uvicorn
 
+    from worldkernels.bootstrap import ProgressController
     from worldkernels.core.config import ServerConfig
     from worldkernels.serving.server import create_app
 
-    cfg = ServerConfig(
-        host=host,
-        port=port,
-        max_sessions=max_sessions,
-        api_key=api_key,
-    )
+    if quiet:
+        os.environ["WORLDKERNELS_QUIET"] = "1"
+
+    cfg = ServerConfig(host=host, port=port, max_sessions=max_sessions, api_key=api_key)
     app = create_app(cfg, device=device)
 
     if model is not None:
         from worldkernels.engine import WorldEngine
 
         engine: WorldEngine = app.state.engine
-        print(f"Pre-loading model: {model}")
-        engine.load_model(model, **(model_kwargs or {}))
-        print(f"Model '{model}' ready.")
+        with ProgressController(mode="quiet" if quiet else "plain") as progress:
+            engine.load_model(
+                model,
+                variant=variant,
+                ckpt_path=ckpt_path,
+                progress=progress,
+                allow_fetch=allow_fetch,
+                **(model_kwargs or {}),
+            )
+            progress.finalize(success=True, summary=f"model={model}")
 
+    print(f"  http://{host}:{port}", flush=True)
     uvicorn.run(app, host=host, port=port)

--- a/worldkernels/config/__init__.py
+++ b/worldkernels/config/__init__.py
@@ -8,15 +8,22 @@ from __future__ import annotations
 from worldkernels.config.cache_config import CacheConfig
 from worldkernels.config.engine_config import EngineConfig
 from worldkernels.config.parallel_config import ParallelConfig
+from worldkernels.config.profiles import PROFILES, profile_config, resolve_runtime_config
+from worldkernels.config.runtime import RuntimeConfig, SessionOverrides
 from worldkernels.config.scheduler_config import SchedulerConfig
 from worldkernels.config.server_config import ServerConfig
 from worldkernels.config.world_config import WorldConfig
 
 __all__ = [
+    "RuntimeConfig",
+    "SessionOverrides",
     "EngineConfig",
     "ParallelConfig",
     "CacheConfig",
     "SchedulerConfig",
     "WorldConfig",
     "ServerConfig",
+    "PROFILES",
+    "resolve_runtime_config",
+    "profile_config",
 ]

--- a/worldkernels/config/active.py
+++ b/worldkernels/config/active.py
@@ -1,0 +1,39 @@
+r"""Process-level active RuntimeConfig.
+
+Bake-time gates (torch_compile, quantization, cuda_graphs at warmup) read the
+active config here instead of threading it through every world/pipeline
+signature. The engine sets it at construction. Step-time, per-session toggles
+ride `ForwardContext` instead (set per request).
+
+One engine per process is the common case; a second engine overwrites the
+active config (documented limitation — per-session overrides cover the
+multi-config-in-one-process case at step time).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from worldkernels.config.runtime import RuntimeConfig
+
+_ACTIVE: "RuntimeConfig | None" = None
+
+
+def set_active_config(config: "RuntimeConfig") -> None:
+    global _ACTIVE
+    _ACTIVE = config
+
+
+def get_active_config() -> "RuntimeConfig":
+    global _ACTIVE
+    if _ACTIVE is None:
+        from worldkernels.config.runtime import RuntimeConfig
+
+        _ACTIVE = RuntimeConfig()
+    return _ACTIVE
+
+
+def clear_active_config() -> None:
+    global _ACTIVE
+    _ACTIVE = None

--- a/worldkernels/config/engine_config.py
+++ b/worldkernels/config/engine_config.py
@@ -1,31 +1,13 @@
-r"""Top-level engine configuration composing the runtime sub-configs."""
+r"""Engine configuration.
+
+``EngineConfig`` is retained as a deprecated alias for `RuntimeConfig`, which
+is now the single source of truth for engine settings + component toggles.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from typing import Literal
-
-from worldkernels.config.cache_config import CacheConfig
-from worldkernels.config.parallel_config import ParallelConfig
-from worldkernels.config.scheduler_config import SchedulerConfig
+from worldkernels.config.runtime import RuntimeConfig
 
 __all__ = ["EngineConfig"]
 
-
-@dataclass
-class EngineConfig:
-    r"""Process-wide engine configuration.
-
-    Args:
-        device: Compute device (``"cuda"``, ``"cpu"``, or ``"cuda:N"``).
-        dtype: Compute precision; ``"auto"`` picks bf16 on Ampere+, else fp16.
-        parallel: Multi-GPU parallelism degrees.
-        cache: Block-memory and caching policy.
-        scheduler: Continuous-batching scheduler policy.
-    """
-
-    device: str = "cuda"
-    dtype: Literal["bf16", "fp16", "fp32", "auto"] = "auto"
-    parallel: ParallelConfig = field(default_factory=ParallelConfig)
-    cache: CacheConfig = field(default_factory=CacheConfig)
-    scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
+EngineConfig = RuntimeConfig

--- a/worldkernels/config/profiles.py
+++ b/worldkernels/config/profiles.py
@@ -71,9 +71,7 @@ def resolve_runtime_config(
 
     if profile:
         if profile not in PROFILES:
-            raise ValueError(
-                f"unknown profile {profile!r}; choices: {sorted(PROFILES)}"
-            )
+            raise ValueError(f"unknown profile {profile!r}; choices: {sorted(PROFILES)}")
         for field_name, value in PROFILES[profile].items():
             setattr(cfg, field_name, value)
             sources[field_name] = f"profile:{profile}"

--- a/worldkernels/config/profiles.py
+++ b/worldkernels/config/profiles.py
@@ -1,0 +1,132 @@
+r"""Ablation profiles + precedence resolver for RuntimeConfig.
+
+Precedence (lowest to highest): built-in defaults < profile < env (WK_*) < CLI.
+``resolve_runtime_config`` returns the resolved config plus a per-field source
+map so ``worldkernels config show`` can attribute every value.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from worldkernels.config.runtime import (
+    ALL_TOGGLE_FIELDS,
+    TOGGLE_BOOL_FIELDS,
+    TOGGLE_ENUM_FIELDS,
+    RuntimeConfig,
+)
+
+__all__ = ["PROFILES", "resolve_runtime_config", "profile_config"]
+
+PROFILES: dict[str, dict[str, Any]] = {
+    "baseline": {
+        "torch_compile": False,
+        "cuda_graphs": False,
+        "continuous_batching": False,
+        "iteration_batching": False,
+        "teacache": False,
+        "trajectory_cache": False,
+        "kv_cache_paged": False,
+        "latent_pool": False,
+        "offload_idle": False,
+        "attention_backend": "sdpa",
+    },
+    "default": {},
+    "fast": {"teacache": True},
+    "production": {"teacache": True, "quantization": "int8"},
+}
+
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"0", "false", "no", "off"}
+
+
+def profile_config(name: str) -> RuntimeConfig:
+    r"""Materialize a profile into a RuntimeConfig (defaults + profile overrides)."""
+    cfg, _ = resolve_runtime_config(profile=name)
+    return cfg
+
+
+def resolve_runtime_config(
+    profile: str | None = None,
+    cli_overrides: dict[str, Any] | None = None,
+    env: "os._Environ[str] | dict[str, str] | None" = None,
+) -> tuple[RuntimeConfig, dict[str, str]]:
+    r"""Resolve a RuntimeConfig under the precedence chain.
+
+    Args:
+        profile: Named profile from `PROFILES` (e.g. ``"baseline"``).
+        cli_overrides: ``{field: value}`` from CLI flags (``None`` values ignored).
+        env: Environment mapping (defaults to ``os.environ``).
+
+    Returns:
+        ``(config, sources)`` where ``sources[field]`` is one of ``"default"``,
+        ``"profile:<name>"``, ``"env:<VAR>"``, ``"cli:--<flag>"``.
+    """
+    env = os.environ if env is None else env
+    overrides = dict(cli_overrides or {})
+
+    cfg = RuntimeConfig()
+    sources: dict[str, str] = {f: "default" for f in ALL_TOGGLE_FIELDS}
+
+    if profile:
+        if profile not in PROFILES:
+            raise ValueError(
+                f"unknown profile {profile!r}; choices: {sorted(PROFILES)}"
+            )
+        for field_name, value in PROFILES[profile].items():
+            setattr(cfg, field_name, value)
+            sources[field_name] = f"profile:{profile}"
+
+    for field_name, value, var in _env_overrides(env):
+        setattr(cfg, field_name, value)
+        sources[field_name] = f"env:{var}"
+
+    for field_name, value in overrides.items():
+        if value is None or field_name not in sources:
+            continue
+        setattr(cfg, field_name, value)
+        sources[field_name] = f"cli:--{field_name.replace('_', '-')}"
+
+    return cfg, sources
+
+
+def _env_overrides(env) -> list[tuple[str, Any, str]]:
+    out: list[tuple[str, Any, str]] = []
+
+    disable = env.get("WK_DISABLE", "")
+    for name in _split_csv(disable):
+        if name in TOGGLE_BOOL_FIELDS:
+            out.append((name, False, "WK_DISABLE"))
+
+    enable = env.get("WK_ENABLE", "")
+    for name in _split_csv(enable):
+        if name in TOGGLE_BOOL_FIELDS:
+            out.append((name, True, "WK_ENABLE"))
+
+    for name in TOGGLE_BOOL_FIELDS:
+        var = f"WK_{name.upper()}"
+        if var in env:
+            out.append((name, _coerce_bool(env[var]), var))
+
+    for name, allowed in TOGGLE_ENUM_FIELDS.items():
+        var = f"WK_{name.upper()}"
+        if var in env:
+            val = env[var].strip().lower()
+            if val in allowed:
+                out.append((name, val, var))
+
+    return out
+
+
+def _split_csv(value: str) -> list[str]:
+    return [v.strip() for v in value.split(",") if v.strip()]
+
+
+def _coerce_bool(value: str) -> bool:
+    v = value.strip().lower()
+    if v in _TRUE:
+        return True
+    if v in _FALSE:
+        return False
+    return bool(v)

--- a/worldkernels/config/runtime.py
+++ b/worldkernels/config/runtime.py
@@ -1,0 +1,106 @@
+r"""RuntimeConfig — the single source of truth for component toggles.
+
+A flat "switch panel": one field per worldkernels component, so benchmarks,
+ablations, and demos can flip any subsystem on or off. Structured (non-toggle)
+parameters stay in the nested `ParallelConfig` / `CacheConfig` / `SchedulerConfig`.
+
+Import-light (no torch) — safe on the CLI cold path.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from worldkernels.config.cache_config import CacheConfig
+from worldkernels.config.parallel_config import ParallelConfig
+from worldkernels.config.scheduler_config import SchedulerConfig
+
+__all__ = [
+    "RuntimeConfig",
+    "SessionOverrides",
+    "TOGGLE_BOOL_FIELDS",
+    "TOGGLE_ENUM_FIELDS",
+    "ALL_TOGGLE_FIELDS",
+    "SESSION_OVERRIDE_FIELDS",
+]
+
+
+@dataclass
+class RuntimeConfig:
+    r"""Process-wide engine configuration and component switch panel.
+
+    Every optimization is a field here. Defaults preserve current behavior.
+    Flags split into *bake-time* (device/dtype/quantization/torch_compile/
+    cuda_graphs — fixed at init or warmup) and *runtime* (caching, batching,
+    placement, attention — some flip per-session via `SessionOverrides`).
+    """
+
+    device: str = "cuda"
+    dtype: Literal["auto", "bf16", "fp16", "fp32"] = "auto"
+    quantization: Literal["none", "int8", "int4"] = "none"
+
+    torch_compile: bool = True
+    cuda_graphs: bool = True
+
+    continuous_batching: bool = True
+    iteration_batching: bool = True
+
+    teacache: bool = False
+    trajectory_cache: bool = True
+    kv_cache_paged: bool = True
+    latent_pool: bool = True
+
+    offload_idle: bool = True
+
+    attention_backend: Literal["auto", "flash", "sdpa"] = "auto"
+
+    isolation: Literal["auto", "shared", "isolated"] = "auto"
+
+    max_sessions: int = 4
+
+    parallel: ParallelConfig = field(default_factory=ParallelConfig)
+    cache: CacheConfig = field(default_factory=CacheConfig)
+    scheduler: SchedulerConfig = field(default_factory=SchedulerConfig)
+
+
+@dataclass
+class SessionOverrides:
+    r"""Per-session toggle overrides — only the subset safe to flip without a
+    warmup/load rebake. ``None`` means "inherit the engine value"."""
+
+    teacache: bool | None = None
+    trajectory_cache: bool | None = None
+    iteration_batching: bool | None = None
+    offload_idle: bool | None = None
+    attention_backend: Literal["auto", "flash", "sdpa"] | None = None
+
+
+TOGGLE_BOOL_FIELDS: tuple[str, ...] = (
+    "torch_compile",
+    "cuda_graphs",
+    "continuous_batching",
+    "iteration_batching",
+    "teacache",
+    "trajectory_cache",
+    "kv_cache_paged",
+    "latent_pool",
+    "offload_idle",
+)
+
+TOGGLE_ENUM_FIELDS: dict[str, tuple[str, ...]] = {
+    "dtype": ("auto", "bf16", "fp16", "fp32"),
+    "quantization": ("none", "int8", "int4"),
+    "attention_backend": ("auto", "flash", "sdpa"),
+    "isolation": ("auto", "shared", "isolated"),
+}
+
+ALL_TOGGLE_FIELDS: tuple[str, ...] = TOGGLE_BOOL_FIELDS + tuple(TOGGLE_ENUM_FIELDS)
+
+SESSION_OVERRIDE_FIELDS: tuple[str, ...] = (
+    "teacache",
+    "trajectory_cache",
+    "iteration_batching",
+    "offload_idle",
+    "attention_backend",
+)

--- a/worldkernels/core/request.py
+++ b/worldkernels/core/request.py
@@ -38,3 +38,4 @@ class StepRequest:
     modalities: list[str] = field(default_factory=lambda: ["frames"])
     step_index: int = 0
     decode: bool = True
+    overrides: dict | None = None

--- a/worldkernels/core/session.py
+++ b/worldkernels/core/session.py
@@ -82,6 +82,9 @@ class Session:
     _world: WorldModel | None = field(default=None, repr=False)
     _scheduler: Scheduler | None = field(default=None, repr=False)
 
+    # Per-session runtime overrides (SESSION_OVERRIDE_FIELDS subset)
+    overrides: dict | None = None
+
     # ---- core hot path ---------------------------------------------------
 
     def step(
@@ -124,6 +127,7 @@ class Session:
             modalities=modalities,
             step_index=self.step_index,
             decode=decode,
+            overrides=self.overrides,
         )
 
         self.state = new_state

--- a/worldkernels/engine/async_engine.py
+++ b/worldkernels/engine/async_engine.py
@@ -42,6 +42,8 @@ class AsyncEngine:
     def __init__(self, engine: "WorldEngine", *, batch_window: float = 0.005) -> None:
         self.engine = engine
         self.batch_window = batch_window
+        _cfg = getattr(engine, "config", None)
+        self._continuous_batching = getattr(_cfg, "continuous_batching", True)
         self._pending: dict[str, asyncio.Future] = {}
         self._drain_task: asyncio.Task | None = None
         self._closed = False
@@ -119,13 +121,15 @@ class AsyncEngine:
 
     async def _drain_loop(self) -> None:
         scheduler = self.engine._scheduler
+        wait = self.batch_window if self._continuous_batching else 0.0
+        cap = None if self._continuous_batching else 1
         while not self._closed:
-            await asyncio.sleep(self.batch_window)
+            await asyncio.sleep(wait)
             batch = scheduler.pending
             if not batch:
                 continue
             try:
-                results = await asyncio.to_thread(scheduler.run_scheduled)
+                results = await asyncio.to_thread(scheduler.run_scheduled, cap)
             except Exception as exc:  # noqa: BLE001 - surface compute errors to callers
                 self._fail_pending(exc)
                 continue

--- a/worldkernels/engine/async_engine.py
+++ b/worldkernels/engine/async_engine.py
@@ -44,9 +44,13 @@ class AsyncEngine:
         self.batch_window = batch_window
         _cfg = getattr(engine, "config", None)
         self._continuous_batching = getattr(_cfg, "continuous_batching", True)
+        self._offload_idle = getattr(_cfg, "offload_idle", False)
+        self._compute_device = getattr(engine, "device", "cuda")
         self._pending: dict[str, asyncio.Future] = {}
         self._drain_task: asyncio.Task | None = None
         self._closed = False
+        self.offload_count = 0
+        self.restore_count = 0
 
     async def load_model(self, model_id: str, **kwargs: Any) -> None:
         await asyncio.to_thread(self.engine.load_model, model_id, **kwargs)
@@ -59,8 +63,11 @@ class AsyncEngine:
         world: str,
         config: "WorldConfig | None" = None,
         seed: int | None = None,
+        overrides: dict | None = None,
     ) -> "Session":
-        session = await asyncio.to_thread(self.engine.create_session, world, config, seed)
+        session = await asyncio.to_thread(
+            self.engine.create_session, world, config, seed, overrides
+        )
         metrics.set_active_sessions(len(self.engine.list_sessions()))
         return session
 
@@ -88,6 +95,10 @@ class AsyncEngine:
             raise SessionPausedError(session_id)
         if session_id in self._pending:
             raise RuntimeError(f"a step is already in flight for session {session_id!r}")
+
+        if self._offload_idle and session.state.device != self._compute_device:
+            session.state = session.state.to(self._compute_device)
+            self.restore_count += 1
 
         self._ensure_drain_loop()
         future: asyncio.Future = asyncio.get_running_loop().create_future()
@@ -136,6 +147,8 @@ class AsyncEngine:
             metrics.observe_batch(batch)
             for session_id, (new_state, obs) in results.items():
                 self._resolve(session_id, new_state, obs)
+            if self._offload_idle:
+                self._offload_non_active(active=set(results.keys()))
 
     def _fail_pending(self, exc: BaseException) -> None:
         r"""Fail every awaiting step with ``exc`` rather than hang on a dead batch."""
@@ -143,6 +156,17 @@ class AsyncEngine:
             if not future.done():
                 future.set_exception(exc)
         self._pending.clear()
+
+    def _offload_non_active(self, active: set[str]) -> None:
+        for sid, session in self.engine._sessions.items():
+            if sid in active:
+                continue
+            ov = session.overrides or {}
+            if ov.get("offload_idle") is False:
+                continue
+            if session.state.device != "cpu":
+                session.state = session.state.to("cpu")
+                self.offload_count += 1
 
     def _resolve(self, session_id: str, new_state: Any, obs: "Observation") -> None:
         session = self.engine.get_session(session_id)

--- a/worldkernels/engine/world_engine.py
+++ b/worldkernels/engine/world_engine.py
@@ -78,38 +78,51 @@ class WorldEngine:
         self,
         model_id: str,
         alias: str | None = None,
+        variant: str | None = None,
+        ckpt_path: str | None = None,
+        progress: Any = None,
+        allow_fetch: bool = True,
         trust_remote_code: bool = False,
         **kwargs: Any,
     ) -> None:
-        r"""Load a world model by short name, HF repo ID, or registry name.
+        r"""Load a world model from a hub alias, HF repo id, or local checkpoint path.
 
-        Resolution order: hub (short names + HF IDs) -> worlds registry. Hub
-        default kwargs are merged with user kwargs (user wins). Generators are
-        resolved to `GeneratorWorld` automatically.
+        Drives the full bootstrap pipeline (resolve → deps → packages → weights → init)
+        through `worldkernels.bootstrap.prepare`.
 
         Args:
-            model_id: Short name, HF repo ID, or adapter registry name.
-            alias: Optional short name for the loaded model.
-            trust_remote_code: Allow custom code from HF Hub.
-            **kwargs: Forwarded to the world constructor.
+            model_id: Short alias, HF repo id, HF URL, or local path.
+            alias: Override the in-engine key (defaults to a slug of ``model_id``).
+            variant: Pick a variant from the model card (e.g. ``"2b_gr1"``).
+            ckpt_path: Bypass HF download with a local checkpoint file.
+            progress: Optional `ProgressController` (CLI/HTTP pass theirs through).
+            allow_fetch: If ``False``, errors instead of installing/cloning/downloading.
+            trust_remote_code: Allow custom code from HF Hub (reserved; not yet enforced).
+            **kwargs: Forwarded to the world constructor (overrides card defaults).
         """
+        from worldkernels.bootstrap import prepare
         from worldkernels.config import WorldConfig as WC
-        from worldkernels.worlds.hub import ensure_model_deps, resolve_model
         from worldkernels.worlds.registry import get_world_class
 
-        ensure_model_deps(model_id)
-        adapter_name, merged_kwargs = resolve_model(model_id, **kwargs)
+        prepared = prepare(
+            model_id,
+            variant=variant,
+            ckpt_path=ckpt_path,
+            progress=progress,
+            allow_fetch=allow_fetch,
+            **kwargs,
+        )
+        key = alias or prepared.alias
 
-        key = alias or model_id.split("/")[-1]
         if key in self._worlds:
             raise WorldAlreadyLoadedError(key)
 
         try:
-            world_cls = get_world_class(adapter_name)
+            world_cls = get_world_class(prepared.adapter)
         except KeyError:
             raise WorldNotFoundError(model_id)
 
-        world: WorldModel = world_cls(**merged_kwargs)
+        world: WorldModel = world_cls(**prepared.kwargs)
         try:
             world.initialize(device=self.device, dtype=self.dtype)
         except Exception as exc:

--- a/worldkernels/engine/world_engine.py
+++ b/worldkernels/engine/world_engine.py
@@ -105,12 +105,16 @@ class WorldEngine:
             **kwargs: Forwarded to the world constructor (overrides card defaults).
         """
         from worldkernels.bootstrap import prepare
+        from worldkernels.bootstrap.errors import ModelNotFoundError as _ModelNotFoundError
         from worldkernels.bootstrap.resolve import resolve as _resolve_ref
         from worldkernels.config import WorldConfig as WC
         from worldkernels.runtime.resolver import IsolatedPlan, resolve_install_plan
         from worldkernels.worlds.registry import get_world_class
 
-        resolved = _resolve_ref(model_id, variant=variant, ckpt_path=ckpt_path)
+        try:
+            resolved = _resolve_ref(model_id, variant=variant, ckpt_path=ckpt_path)
+        except _ModelNotFoundError as exc:
+            raise WorldNotFoundError(model_id) from exc
         card = resolved.card
         plan = resolve_install_plan(card, list(self._cards.values()))
 

--- a/worldkernels/engine/world_engine.py
+++ b/worldkernels/engine/world_engine.py
@@ -100,11 +100,18 @@ class WorldEngine:
         self._sessions: dict[str, Session] = {}
         self._tiers: dict[str, str] = {}
         self._cards: dict[str, Any] = {}
+        self.trajectory_cache = None
+        if cfg.trajectory_cache:
+            from worldkernels.runtime.memory.trajectory_cache import TrajectoryCache
+
+            self.trajectory_cache = TrajectoryCache()
 
         from worldkernels.scheduler import Scheduler
         from worldkernels.worker import Worker
 
-        self._worker = Worker(device=self.device, dtype=self.dtype, parallel_config=cfg.parallel)
+        self._worker = Worker(
+            device=self.device, dtype=self.dtype, parallel_config=cfg.parallel, config=cfg
+        )
         self._scheduler = Scheduler(self._worker, config=cfg.scheduler)
 
         log.info(
@@ -174,6 +181,18 @@ class WorldEngine:
             except Exception:
                 pass
             raise WorldAlreadyLoadedError(key)
+
+        if getattr(world, "supports_kv_cache", False) and self.config.kv_cache_paged:
+            self._worker.runner.ensure_kv_cache(
+                frames_per_block=self.config.cache.block_frames,
+            )
+
+        if self.config.quantization != "none":
+            target = getattr(world, "_quant_target", None)
+            if target is not None:
+                from worldkernels.runtime.quantization.registry import QuantizationRegistry
+
+                QuantizationRegistry().apply(target, self.config.quantization)
 
         try:
             world.warmup(getattr(world, "default_config", None) or WC())
@@ -281,15 +300,35 @@ class WorldEngine:
         world: str,
         config: WorldConfig | None = None,
         seed: int | None = None,
+        overrides: dict | Any = None,
     ) -> Session:
-        r"""Create a new simulation session bound to a loaded world model."""
+        r"""Create a new simulation session bound to a loaded world model.
+
+        Args:
+            overrides: `SessionOverrides` or ``{flag: value}`` — flips a subset
+                of toggles for this session only (`SESSION_OVERRIDE_FIELDS`).
+                Bake-time flags (torch_compile, dtype, quantization,
+                cuda_graphs, kv_cache_paged, latent_pool) are ignored with a
+                ``log.warning`` since they can't change after init/warmup.
+        """
         from worldkernels.config import WorldConfig as WC
+        from worldkernels.config.runtime import SESSION_OVERRIDE_FIELDS
         from worldkernels.core.session import Session
 
         if world not in self._worlds:
             raise WorldNotFoundError(world)
         if len(self._sessions) >= self.max_sessions:
             raise SessionLimitError(self.max_sessions)
+
+        ov = _normalize_overrides(overrides)
+        if ov is not None:
+            for k in list(ov):
+                if k not in SESSION_OVERRIDE_FIELDS:
+                    log.warning(
+                        "ignoring session override %r: not in the per-session-safe subset",
+                        k,
+                    )
+                    ov.pop(k)
 
         cfg = config or WC()
         actual_seed = seed if seed is not None else 0
@@ -309,6 +348,7 @@ class WorldEngine:
             seed=actual_seed,
             _world=world_instance,
             _scheduler=self._scheduler,
+            overrides=ov,
         )
         self._sessions[session.session_id] = session
         log.info("Created session: %s (world=%s)", session.session_id, world)
@@ -350,6 +390,19 @@ class WorldEngine:
         r"""Return the isolation tier (``"shared"`` / ``"isolated"``) for a loaded model."""
         return self._tiers.get(name)
 
+    def lookup_trajectory_prefix(self, action_hashes: list[str]):
+        r"""Return the longest cached prefix of ``action_hashes``, or ``None`` if disabled."""
+        if self.trajectory_cache is None:
+            return None
+        return self.trajectory_cache.match(action_hashes)
+
+    def cache_trajectory(self, action_hashes: list[str], block_ids: list[int]) -> bool:
+        r"""Insert an action-history → block-id mapping; ``False`` if cache is off."""
+        if self.trajectory_cache is None:
+            return False
+        self.trajectory_cache.insert(action_hashes, block_ids)
+        return True
+
     def list_tiers(self) -> dict[str, str]:
         return dict(self._tiers)
 
@@ -368,6 +421,20 @@ class WorldEngine:
         self._tiers.clear()
         self._cards.clear()
         log.info("WorldEngine shut down.")
+
+
+def _normalize_overrides(value) -> dict | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return {k: v for k, v in value.items() if v is not None}
+    import dataclasses
+
+    if dataclasses.is_dataclass(value):
+        return {k: v for k, v in dataclasses.asdict(value).items() if v is not None}
+    raise TypeError(
+        f"overrides must be dict, SessionOverrides, or None; got {type(value).__name__}"
+    )
 
 
 def _emit_tier_metric(model_id: str, tier: str) -> None:

--- a/worldkernels/engine/world_engine.py
+++ b/worldkernels/engine/world_engine.py
@@ -430,7 +430,7 @@ def _normalize_overrides(value) -> dict | None:
         return {k: v for k, v in value.items() if v is not None}
     import dataclasses
 
-    if dataclasses.is_dataclass(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
         return {k: v for k, v in dataclasses.asdict(value).items() if v is not None}
     raise TypeError(
         f"overrides must be dict, SessionOverrides, or None; got {type(value).__name__}"

--- a/worldkernels/engine/world_engine.py
+++ b/worldkernels/engine/world_engine.py
@@ -60,6 +60,8 @@ class WorldEngine:
 
         self._worlds: dict[str, WorldModel] = {}
         self._sessions: dict[str, Session] = {}
+        self._tiers: dict[str, str] = {}
+        self._cards: dict[str, Any] = {}
 
         from worldkernels.scheduler import Scheduler
         from worldkernels.worker import Worker
@@ -87,21 +89,70 @@ class WorldEngine:
     ) -> None:
         r"""Load a world model from a hub alias, HF repo id, or local checkpoint path.
 
-        Drives the full bootstrap pipeline (resolve → deps → packages → weights → init)
-        through `worldkernels.bootstrap.prepare`.
+        Drives the resolver (ADR-012): the resolver decides whether the model can
+        share the current env or needs an isolated subprocess. Shared models go
+        through `worldkernels.bootstrap.prepare` and instantiate locally; isolated
+        models materialize a per-model uv venv and are accessed via `RemoteWorld`.
 
         Args:
             model_id: Short alias, HF repo id, HF URL, or local path.
             alias: Override the in-engine key (defaults to a slug of ``model_id``).
-            variant: Pick a variant from the model card (e.g. ``"2b_gr1"``).
+            variant: Pick a variant from the model card.
             ckpt_path: Bypass HF download with a local checkpoint file.
             progress: Optional `ProgressController` (CLI/HTTP pass theirs through).
             allow_fetch: If ``False``, errors instead of installing/cloning/downloading.
-            trust_remote_code: Allow custom code from HF Hub (reserved; not yet enforced).
+            trust_remote_code: Allow custom code from HF Hub (reserved).
             **kwargs: Forwarded to the world constructor (overrides card defaults).
         """
         from worldkernels.bootstrap import prepare
+        from worldkernels.bootstrap.resolve import resolve as _resolve_ref
         from worldkernels.config import WorldConfig as WC
+        from worldkernels.runtime.resolver import IsolatedPlan, resolve_install_plan
+        from worldkernels.worlds.registry import get_world_class
+
+        resolved = _resolve_ref(model_id, variant=variant, ckpt_path=ckpt_path)
+        card = resolved.card
+        plan = resolve_install_plan(card, list(self._cards.values()))
+
+        if isinstance(plan, IsolatedPlan):
+            world, key, tier = self._load_isolated(
+                model_id, resolved, plan, alias, progress, allow_fetch, kwargs
+            )
+        else:
+            world, key, tier = self._load_shared(
+                model_id, alias, variant, ckpt_path, progress, allow_fetch, kwargs
+            )
+
+        if key in self._worlds:
+            try:
+                world.close()  # type: ignore[attr-defined]
+            except Exception:
+                pass
+            raise WorldAlreadyLoadedError(key)
+
+        try:
+            world.warmup(getattr(world, "default_config", None) or WC())
+        except Exception as exc:
+            raise WorldInitError(model_id, f"warmup failed: {exc}") from exc
+
+        self._worlds[key] = world
+        self._tiers[key] = tier
+        self._cards[key] = card
+        _emit_tier_metric(key, tier)
+        _emit_worker_count(self._tiers)
+        log.info("Loaded world: %s (tier=%s, class=%s)", key, tier, type(world).__name__)
+
+    def _load_shared(
+        self,
+        model_id: str,
+        alias: str | None,
+        variant: str | None,
+        ckpt_path: str | None,
+        progress: Any,
+        allow_fetch: bool,
+        kwargs: dict[str, Any],
+    ) -> tuple[Any, str, str]:
+        from worldkernels.bootstrap import prepare
         from worldkernels.worlds.registry import get_world_class
 
         prepared = prepare(
@@ -113,25 +164,72 @@ class WorldEngine:
             **kwargs,
         )
         key = alias or prepared.alias
-
-        if key in self._worlds:
-            raise WorldAlreadyLoadedError(key)
-
         try:
             world_cls = get_world_class(prepared.adapter)
-        except KeyError:
-            raise WorldNotFoundError(model_id)
+        except KeyError as exc:
+            raise WorldNotFoundError(model_id) from exc
 
-        world: WorldModel = world_cls(**prepared.kwargs)
+        world = world_cls(**prepared.kwargs)
         try:
             world.initialize(device=self.device, dtype=self.dtype)
         except Exception as exc:
             raise WorldInitError(model_id, str(exc)) from exc
+        return world, key, "shared"
 
-        world.warmup(world.default_config or WC())
+    def _load_isolated(
+        self,
+        model_id: str,
+        resolved: Any,
+        plan: Any,
+        alias: str | None,
+        progress: Any,
+        allow_fetch: bool,
+        kwargs: dict[str, Any],
+    ) -> tuple[Any, str, str]:
+        from worldkernels.runtime import envs
+        from worldkernels.worlds.remote import RemoteWorld
 
-        self._worlds[key] = world
-        log.info("Loaded world: %s (class=%s)", key, world_cls.__qualname__)
+        if progress is not None:
+            progress.event("isolating", "running", f"reason: {plan.reason}")
+
+        requirements = list(plan.requirements)
+        if "worldkernels" not in " ".join(requirements):
+            requirements.append("worldkernels")
+
+        envs.materialize_env(
+            model_id,
+            requirements,
+            device=self.device,
+            progress=progress,
+            allow_fetch=allow_fetch,
+        )
+
+        ctor_kwargs: dict[str, Any] = dict(resolved.card.default_kwargs)
+        if resolved.variant is not None:
+            ctor_kwargs["variant"] = resolved.variant
+        if resolved.ckpt_path is not None:
+            ctor_kwargs["ckpt_path"] = resolved.ckpt_path
+        ctor_kwargs.update(kwargs)
+
+        key = alias or self._alias_for(model_id, resolved.variant)
+        world = RemoteWorld(
+            model_id=model_id,
+            adapter=resolved.card.adapter,
+            ctor_kwargs=ctor_kwargs,
+        )
+        try:
+            world.initialize(device=self.device, dtype=self.dtype)
+        except Exception as exc:
+            try:
+                world.close()
+            finally:
+                raise WorldInitError(model_id, str(exc)) from exc
+        return world, key, "isolated"
+
+    @staticmethod
+    def _alias_for(model_id: str, variant: str | None) -> str:
+        base = model_id.split("/")[-1]
+        return f"{base}:{variant}" if variant else base
 
     def create_session(
         self,
@@ -191,12 +289,55 @@ class WorldEngine:
             raise WorldNotFoundError(name)
         for sid in [s for s, sess in self._sessions.items() if sess.world_id == name]:
             self.close_session(sid)
-        del self._worlds[name]
+        world = self._worlds.pop(name)
+        self._tiers.pop(name, None)
+        self._cards.pop(name, None)
+        close = getattr(world, "close", None)
+        if callable(close):
+            try:
+                close()
+            except Exception as exc:
+                log.warning("error closing world %r: %s", name, exc)
+        _emit_worker_count(self._tiers)
         log.info("Unloaded world: %s", name)
+
+    def get_tier(self, name: str) -> str | None:
+        r"""Return the isolation tier (``"shared"`` / ``"isolated"``) for a loaded model."""
+        return self._tiers.get(name)
+
+    def list_tiers(self) -> dict[str, str]:
+        return dict(self._tiers)
 
     def shutdown(self) -> None:
         for session in self._sessions.values():
             session.close()
         self._sessions.clear()
+        for name, world in list(self._worlds.items()):
+            close = getattr(world, "close", None)
+            if callable(close):
+                try:
+                    close()
+                except Exception as exc:
+                    log.warning("error closing world %r during shutdown: %s", name, exc)
         self._worlds.clear()
+        self._tiers.clear()
+        self._cards.clear()
         log.info("WorldEngine shut down.")
+
+
+def _emit_tier_metric(model_id: str, tier: str) -> None:
+    try:
+        from worldkernels.runtime import metrics
+
+        metrics.set_isolation_tier(model_id, 0 if tier == "shared" else 1)
+    except Exception:
+        pass
+
+
+def _emit_worker_count(tiers: dict[str, str]) -> None:
+    try:
+        from worldkernels.runtime import metrics
+
+        metrics.set_worker_processes(sum(1 for t in tiers.values() if t == "isolated"))
+    except Exception:
+        pass

--- a/worldkernels/engine/world_engine.py
+++ b/worldkernels/engine/world_engine.py
@@ -21,7 +21,7 @@ from worldkernels.core.errors import (
 )
 
 if TYPE_CHECKING:
-    from worldkernels.config import WorldConfig
+    from worldkernels.config import RuntimeConfig, WorldConfig
     from worldkernels.core.session import Session
     from worldkernels.worlds.base import WorldModel
 
@@ -38,6 +38,12 @@ def _default_dtype(device: str) -> torch.dtype:
     return torch.float32
 
 
+def _resolve_dtype(dtype: str, device: str) -> torch.dtype:
+    if dtype == "auto":
+        return _default_dtype(device)
+    return {"bf16": torch.bfloat16, "fp16": torch.float16, "fp32": torch.float32}[dtype]
+
+
 class WorldEngine:
     r"""GPU-first world-model simulation engine.
 
@@ -49,14 +55,46 @@ class WorldEngine:
 
     def __init__(
         self,
-        device: str = "cuda",
-        max_sessions: int = 4,
-        offload_idle: bool = True,
+        config: "RuntimeConfig | str | None" = None,
+        *,
+        device: str | None = None,
+        max_sessions: int | None = None,
+        offload_idle: bool | None = None,
     ) -> None:
-        self.device = device
-        self.max_sessions = max_sessions
-        self.offload_idle = offload_idle
-        self.dtype = _default_dtype(device)
+        r"""Construct the engine from a `RuntimeConfig` (or profile name).
+
+        Args:
+            config: A `RuntimeConfig`, a profile name (``"baseline"`` etc.), or
+                ``None`` for resolved defaults (honoring ``WK_*`` env vars).
+            device: Back-compat override of ``config.device``.
+            max_sessions: Back-compat override of ``config.max_sessions``.
+            offload_idle: Back-compat override of ``config.offload_idle``.
+        """
+        from worldkernels.config.active import set_active_config
+        from worldkernels.config.profiles import resolve_runtime_config
+        from worldkernels.config.runtime import RuntimeConfig
+
+        if isinstance(config, RuntimeConfig):
+            cfg = config
+        elif isinstance(config, str):
+            cfg, _ = resolve_runtime_config(profile=config)
+        else:
+            cfg, _ = resolve_runtime_config()
+
+        if device is not None:
+            cfg.device = device
+        if max_sessions is not None:
+            cfg.max_sessions = max_sessions
+        if offload_idle is not None:
+            cfg.offload_idle = offload_idle
+
+        self.config = cfg
+        set_active_config(cfg)
+
+        self.device = cfg.device
+        self.max_sessions = cfg.max_sessions
+        self.offload_idle = cfg.offload_idle
+        self.dtype = _resolve_dtype(cfg.dtype, cfg.device)
 
         self._worlds: dict[str, WorldModel] = {}
         self._sessions: dict[str, Session] = {}
@@ -66,14 +104,14 @@ class WorldEngine:
         from worldkernels.scheduler import Scheduler
         from worldkernels.worker import Worker
 
-        self._worker = Worker(device=device, dtype=self.dtype)
-        self._scheduler = Scheduler(self._worker)
+        self._worker = Worker(device=self.device, dtype=self.dtype, parallel_config=cfg.parallel)
+        self._scheduler = Scheduler(self._worker, config=cfg.scheduler)
 
         log.info(
             "WorldEngine initialized: device=%s, dtype=%s, max_sessions=%d",
-            device,
+            self.device,
             self.dtype,
-            max_sessions,
+            self.max_sessions,
         )
 
     def load_model(
@@ -104,18 +142,21 @@ class WorldEngine:
             trust_remote_code: Allow custom code from HF Hub (reserved).
             **kwargs: Forwarded to the world constructor (overrides card defaults).
         """
-        from worldkernels.bootstrap import prepare
         from worldkernels.bootstrap.errors import ModelNotFoundError as _ModelNotFoundError
         from worldkernels.bootstrap.resolve import resolve as _resolve_ref
         from worldkernels.config import WorldConfig as WC
         from worldkernels.runtime.resolver import IsolatedPlan, resolve_install_plan
-        from worldkernels.worlds.registry import get_world_class
 
         try:
             resolved = _resolve_ref(model_id, variant=variant, ckpt_path=ckpt_path)
         except _ModelNotFoundError as exc:
             raise WorldNotFoundError(model_id) from exc
         card = resolved.card
+        if card.isolation == "auto" and self.config.isolation != "auto":
+            import dataclasses
+
+            card = dataclasses.replace(card, isolation=self.config.isolation)
+            resolved = dataclasses.replace(resolved, card=card)
         plan = resolve_install_plan(card, list(self._cards.values()))
 
         if isinstance(plan, IsolatedPlan):

--- a/worldkernels/runtime/attention/selector.py
+++ b/worldkernels/runtime/attention/selector.py
@@ -15,12 +15,22 @@ def select_attention_backend(name: str | None = None) -> AttentionBackend:
     r"""Return an attention backend instance.
 
     Args:
-        name: ``"sdpa"`` / ``"flash"``; ``None`` uses the platform default.
-            A requested ``"flash"`` backend silently falls back to SDPA when
-            ``flash-attn`` is not installed.
+        name: ``"sdpa"`` / ``"flash"``. When ``None`` we first consult the
+            active `ForwardContext.attention_backend` (set by `WorldRunner`
+            from `RuntimeConfig.attention_backend`), then fall back to the
+            platform default. A requested ``"flash"`` backend silently falls
+            back to SDPA when ``flash-attn`` is not installed.
     """
     from worldkernels.platforms import current_platform
     from worldkernels.runtime.attention.backends import FlashAttentionBackend, SDPABackend
+
+    if name is None:
+        try:
+            from worldkernels.runtime.forward_context import get_forward_context
+
+            name = get_forward_context().attention_backend
+        except RuntimeError:
+            pass
 
     resolved = name or current_platform().default_attention_backend()
     if resolved == "flash" and FlashAttentionBackend.is_available():

--- a/worldkernels/runtime/compile/torch_compile.py
+++ b/worldkernels/runtime/compile/torch_compile.py
@@ -37,6 +37,11 @@ def regionally_compile(
     """
     import torch
 
+    from worldkernels.config.active import get_active_config
+
+    if not get_active_config().torch_compile:
+        return module
+
     attrs = repeated_block_attrs or getattr(module, "_repeated_blocks", None)
     if not attrs:
         return torch.compile(module, mode=mode)  # type: ignore[return-value]

--- a/worldkernels/runtime/envs.py
+++ b/worldkernels/runtime/envs.py
@@ -71,7 +71,7 @@ def materialize_env(
     if shutil.which("uv") is None:
         raise RuntimeError(
             "uv not found on PATH; required for per-model env materialization. "
-            "uv is a core dependency of worldkernels — try `pip install --force-reinstall worldkernels`."
+            "uv is a core worldkernels dep — try `pip install --force-reinstall worldkernels`."
         )
 
     if progress is not None:

--- a/worldkernels/runtime/envs.py
+++ b/worldkernels/runtime/envs.py
@@ -1,0 +1,129 @@
+r"""Per-model uv venv materialization under ``WORLDKERNELS_HOME/envs/``."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from worldkernels.bootstrap import cache
+from worldkernels.bootstrap.errors import FetchDisabledError
+from worldkernels.runtime.locks import EnvLock, deps_hash, torch_abi_tag
+
+if TYPE_CHECKING:
+    from worldkernels.bootstrap.progress import ProgressController
+
+log = logging.getLogger(__name__)
+
+__all__ = ["envs_dir", "env_path", "venv_python", "materialize_env", "remove_env"]
+
+
+def envs_dir() -> Path:
+    p = cache.home() / "envs"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def env_path(model_id: str) -> Path:
+    return envs_dir() / _slug(model_id)
+
+
+def venv_python(model_id: str) -> Path:
+    base = env_path(model_id)
+    if os.name == "nt":
+        return base / "Scripts" / "python.exe"
+    return base / "bin" / "python"
+
+
+def materialize_env(
+    model_id: str,
+    requirements: list[str],
+    device: str,
+    progress: "ProgressController | None" = None,
+    allow_fetch: bool = True,
+) -> Path:
+    r"""Create or reuse an isolated uv venv for ``model_id``.
+
+    Returns the venv root path. Idempotent: if a lock file matches the requested
+    requirements + torch ABI + device, returns the existing path without
+    touching the venv.
+    """
+    base = env_path(model_id)
+    abi = torch_abi_tag()
+    new_hash = deps_hash(requirements, abi, device)
+
+    existing = EnvLock.read(model_id)
+    if existing is not None and existing.deps_hash == new_hash and venv_python(model_id).exists():
+        if progress is not None:
+            progress.event("isolating", "skipped", f"cached env: {base}")
+        return base
+
+    if not allow_fetch or os.environ.get("WORLDKERNELS_NO_AUTO_INSTALL"):
+        raise FetchDisabledError(
+            f"missing isolated env for {model_id!r}",
+            f"run `worldkernels pull {model_id}` to materialize it",
+        )
+
+    if shutil.which("uv") is None:
+        raise RuntimeError(
+            "uv not found on PATH; required for per-model env materialization. "
+            "uv is a core dependency of worldkernels — try `pip install --force-reinstall worldkernels`."
+        )
+
+    if progress is not None:
+        progress.event("isolating", "running", f"creating {base} …")
+    log.info("Materializing per-model venv at %s", base)
+
+    if base.exists():
+        shutil.rmtree(base)
+
+    _run(["uv", "venv", str(base)], progress=progress)
+
+    if requirements:
+        py = str(venv_python(model_id))
+        if progress is not None:
+            progress.event("isolating", "running", f"installing {len(requirements)} deps …")
+        _run(["uv", "pip", "install", "--python", py, *requirements], progress=progress)
+
+    lock = EnvLock(
+        model_id=model_id,
+        deps_hash=new_hash,
+        torch_abi=abi,
+        device=device,
+        requirements=requirements,
+    )
+    lock.write()
+
+    if progress is not None:
+        progress.event("isolating", "done", f"env ready: {base}")
+    return base
+
+
+def remove_env(model_id: str) -> bool:
+    base = env_path(model_id)
+    lock_path = EnvLock(model_id=model_id, deps_hash="", torch_abi="", device="").path
+    removed = False
+    if base.exists():
+        shutil.rmtree(base)
+        removed = True
+    if lock_path.exists():
+        lock_path.unlink()
+        removed = True
+    return removed
+
+
+def _run(cmd: list[str], progress: "ProgressController | None" = None) -> None:
+    quiet = progress is not None and progress.mode in ("tty", "quiet", "json", "sink")
+    proc = subprocess.run(cmd, check=False, capture_output=quiet, text=True)
+    if proc.returncode != 0:
+        if quiet:
+            sys.stderr.write((proc.stdout or "") + "\n" + (proc.stderr or "") + "\n")
+        raise RuntimeError(f"{' '.join(cmd[:3])} failed (exit {proc.returncode})")
+
+
+def _slug(model_id: str) -> str:
+    return model_id.replace("/", "_").replace(":", "_")

--- a/worldkernels/runtime/executor.py
+++ b/worldkernels/runtime/executor.py
@@ -18,6 +18,7 @@ from worldkernels.runtime.stages import (
 )
 
 if TYPE_CHECKING:
+    from worldkernels.config import RuntimeConfig
     from worldkernels.core.action import Action
     from worldkernels.core.request import StepRequest
     from worldkernels.core.session import LatentState
@@ -32,6 +33,8 @@ class Executor:
         dtype: Target dtype.
         stage_configs: Per-stage execution configs.
         connector: Inter-stage transport. Defaults to ``LocalConnector``.
+        config: Runtime config (component toggles); gates cuda_graphs /
+            iteration_batching / latent_pool / kv_cache (wired incrementally).
     """
 
     def __init__(
@@ -40,9 +43,11 @@ class Executor:
         dtype: torch.dtype,
         stage_configs: tuple[StageConfig, ...] | None = None,
         connector: StageConnector | None = None,
+        config: "RuntimeConfig | None" = None,
     ) -> None:
         self.device = device
         self.dtype = dtype
+        self.config = config
         self.stage_configs = {
             cfg.stage_type: cfg for cfg in (stage_configs or DEFAULT_PIPELINE_STAGES)
         }

--- a/worldkernels/runtime/executor.py
+++ b/worldkernels/runtime/executor.py
@@ -57,6 +57,14 @@ class Executor:
         cfg = self.stage_configs.get(stage_type)
         return cfg is None or cfg.enabled
 
+    def _iteration_batching_enabled(self) -> bool:
+        try:
+            from worldkernels.runtime.forward_context import get_forward_context
+
+            return get_forward_context().iteration_batching
+        except RuntimeError:
+            return bool(self.config and self.config.iteration_batching)
+
     # ---- per-stage execution ---------------------------------------------
 
     @torch.no_grad()
@@ -86,9 +94,18 @@ class Executor:
 
         Treats ``transition()`` as opaque; the world's ``transition_mode``
         determines internal behavior (bidirectional vs causal vs hybrid).
+        When ``iteration_batching`` is on and the world supports it, drives
+        ``transition_iter`` and uses the final yielded state — opening the
+        seam for sessions to join a batch mid-denoise.
         """
         t0 = time.perf_counter()
-        new_state = world.transition(state, action_encoded)
+        iter_batch_on = self._iteration_batching_enabled()
+        if iter_batch_on and getattr(world, "supports_iteration_batching", False):
+            new_state = state
+            for new_state in world.transition_iter(state, action_encoded):
+                pass
+        else:
+            new_state = world.transition(state, action_encoded)
         elapsed = (time.perf_counter() - t0) * 1000.0
         return StageOutput(
             stage_type=StageType.TRANSITION,

--- a/worldkernels/runtime/forward_context.py
+++ b/worldkernels/runtime/forward_context.py
@@ -26,6 +26,10 @@ class ForwardContext:
         attn_metadata: Backend-specific attention state (KV block tables,
             sequence lengths) for the current batch.
         cache_backend: Active denoise-step cache (e.g. TeaCache), or ``None``.
+        pool: Active per-runner buffer pool (`LatentPool`), or ``None``.
+        attention_backend: Resolved attention backend name (``"flash"`` /
+            ``"sdpa"``) when the runtime forces a choice; ``None`` lets the
+            selector fall through to the platform default.
         stream: Current compute CUDA stream, or ``None`` on CPU.
         sp_world_size: Sequence-parallel world size for the active forward.
         sp_padding: Sequence padding added to make the length SP-divisible.
@@ -34,6 +38,9 @@ class ForwardContext:
 
     attn_metadata: Any = None
     cache_backend: Any = None
+    pool: Any = None
+    attention_backend: str | None = None
+    iteration_batching: bool = True
     stream: Any = None
     sp_world_size: int = 1
     sp_padding: int = 0

--- a/worldkernels/runtime/ipc.py
+++ b/worldkernels/runtime/ipc.py
@@ -1,0 +1,209 @@
+r"""Tensor IPC across the engine ↔ worker boundary.
+
+Two paths:
+- **CUDA IPC**: shares the device pointer via ``cudaIpcGetMemHandle``.
+  Zero-copy across processes on the same GPU.
+- **Host shared memory**: ``multiprocessing.shared_memory`` with a D2H/H2D
+  copy. Slower, used when CUDA IPC fails (cgroups, MIG, containers without
+  ``--ipc=host``).
+
+The owner side must keep the source tensor alive until the consumer releases
+the handle (refcounting via the protocol header).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Literal
+
+log = logging.getLogger(__name__)
+
+__all__ = ["IpcHandle", "share_tensor", "recv_tensor", "ipc_available"]
+
+_DISABLE_CUDA_IPC: bool = False
+
+
+def disable_cuda_ipc(disable: bool = True) -> None:
+    r"""Force the host-shm fallback path (used by tests)."""
+    global _DISABLE_CUDA_IPC
+    _DISABLE_CUDA_IPC = disable
+
+
+def ipc_available() -> bool:
+    if _DISABLE_CUDA_IPC:
+        return False
+    try:
+        import torch
+
+        return torch.cuda.is_available()
+    except ImportError:
+        return False
+
+
+@dataclass
+class IpcHandle:
+    r"""Serializable handle for a shared tensor.
+
+    Either ``mode="cuda"`` with ``ipc_payload`` from ``Tensor._share_cuda_()``,
+    or ``mode="shm"`` with the name of a ``multiprocessing.shared_memory`` block.
+    """
+
+    mode: Literal["cuda", "shm"]
+    shape: tuple[int, ...]
+    dtype: str
+    device: str
+    payload: dict[str, Any]
+
+
+def share_tensor(t: Any) -> IpcHandle:
+    if _DISABLE_CUDA_IPC or not _is_cuda_tensor(t):
+        return _share_via_shm(t)
+    try:
+        return _share_via_cuda(t)
+    except (RuntimeError, OSError) as exc:
+        log.warning("CUDA IPC failed (%s); falling back to host shared memory", exc)
+        return _share_via_shm(t)
+
+
+def recv_tensor(handle: IpcHandle) -> Any:
+    if handle.mode == "cuda":
+        return _recv_via_cuda(handle)
+    return _recv_via_shm(handle)
+
+
+def _is_cuda_tensor(t: Any) -> bool:
+    try:
+        import torch
+
+        return isinstance(t, torch.Tensor) and t.is_cuda
+    except ImportError:
+        return False
+
+
+def _share_via_cuda(t: Any) -> IpcHandle:
+    payload = t._share_cuda_()
+    return IpcHandle(
+        mode="cuda",
+        shape=tuple(t.shape),
+        dtype=str(t.dtype),
+        device=str(t.device),
+        payload={
+            "device": payload[0],
+            "handle": payload[1],
+            "size_bytes": payload[2],
+            "offset_bytes": payload[3],
+            "ref_counter_handle": payload[4] if len(payload) > 4 else None,
+            "ref_counter_offset": payload[5] if len(payload) > 5 else None,
+            "event_handle": payload[6] if len(payload) > 6 else None,
+            "event_sync_required": payload[7] if len(payload) > 7 else None,
+        },
+    )
+
+
+def _recv_via_cuda(handle: IpcHandle) -> Any:
+    import torch
+    from torch.multiprocessing.reductions import rebuild_cuda_tensor
+
+    p = handle.payload
+    dtype = _str_to_dtype(handle.dtype)
+    args = (
+        torch.Tensor,
+        handle.shape,
+        (1,) * len(handle.shape),
+        0,
+        dtype,
+        p["device"],
+        p["handle"],
+        p["size_bytes"],
+        p["offset_bytes"],
+        p.get("ref_counter_handle"),
+        p.get("ref_counter_offset"),
+        p.get("event_handle"),
+        p.get("event_sync_required"),
+    )
+    return rebuild_cuda_tensor(*args)
+
+
+def _share_via_shm(t: Any) -> IpcHandle:
+    from multiprocessing import shared_memory
+
+    arr = _tensor_to_numpy(t)
+    shm = shared_memory.SharedMemory(create=True, size=max(1, arr.nbytes))
+    shm.buf[: arr.nbytes] = arr.tobytes()
+    return IpcHandle(
+        mode="shm",
+        shape=tuple(t.shape if hasattr(t, "shape") else arr.shape),
+        dtype=str(getattr(t, "dtype", arr.dtype)),
+        device=str(getattr(t, "device", "cpu")),
+        payload={"name": shm.name, "size_bytes": arr.nbytes},
+    )
+
+
+def _recv_via_shm(handle: IpcHandle) -> Any:
+    import numpy as np
+    from multiprocessing import shared_memory
+
+    shm = shared_memory.SharedMemory(name=handle.payload["name"])
+    dtype = _str_to_numpy_dtype(handle.dtype)
+    nbytes = handle.payload["size_bytes"]
+    arr = np.frombuffer(shm.buf[:nbytes], dtype=dtype).reshape(handle.shape).copy()
+    try:
+        import torch
+
+        out = torch.from_numpy(arr)
+        target_device = handle.device
+        if target_device.startswith("cuda"):
+            out = out.to(target_device)
+        return out
+    except ImportError:
+        return arr
+    finally:
+        shm.close()
+
+
+def _tensor_to_numpy(t: Any):
+    try:
+        import torch
+
+        if isinstance(t, torch.Tensor):
+            return t.detach().contiguous().cpu().numpy()
+    except ImportError:
+        pass
+    import numpy as np
+
+    return np.asarray(t)
+
+
+def _str_to_dtype(name: str):
+    import torch
+
+    table = {
+        "torch.float32": torch.float32,
+        "torch.float16": torch.float16,
+        "torch.bfloat16": torch.bfloat16,
+        "torch.int32": torch.int32,
+        "torch.int64": torch.int64,
+        "torch.uint8": torch.uint8,
+        "torch.bool": torch.bool,
+    }
+    if name in table:
+        return table[name]
+    short = name.split(".")[-1]
+    return getattr(torch, short, torch.float32)
+
+
+def _str_to_numpy_dtype(name: str):
+    import numpy as np
+
+    short = name.split(".")[-1]
+    table = {
+        "float32": np.float32,
+        "float16": np.float16,
+        "bfloat16": np.float32,
+        "int32": np.int32,
+        "int64": np.int64,
+        "uint8": np.uint8,
+        "bool": np.bool_,
+    }
+    return table.get(short, np.float32)

--- a/worldkernels/runtime/ipc.py
+++ b/worldkernels/runtime/ipc.py
@@ -141,8 +141,9 @@ def _share_via_shm(t: Any) -> IpcHandle:
 
 
 def _recv_via_shm(handle: IpcHandle) -> Any:
-    import numpy as np
     from multiprocessing import shared_memory
+
+    import numpy as np
 
     shm = shared_memory.SharedMemory(name=handle.payload["name"])
     dtype = _str_to_numpy_dtype(handle.dtype)

--- a/worldkernels/runtime/ipc.py
+++ b/worldkernels/runtime/ipc.py
@@ -122,7 +122,7 @@ def _recv_via_cuda(handle: IpcHandle) -> Any:
         p.get("event_handle"),
         p.get("event_sync_required"),
     )
-    return rebuild_cuda_tensor(*args)
+    return rebuild_cuda_tensor(*args)  # type: ignore[call-arg]
 
 
 def _share_via_shm(t: Any) -> IpcHandle:
@@ -130,6 +130,7 @@ def _share_via_shm(t: Any) -> IpcHandle:
 
     arr = _tensor_to_numpy(t)
     shm = shared_memory.SharedMemory(create=True, size=max(1, arr.nbytes))
+    assert shm.buf is not None
     shm.buf[: arr.nbytes] = arr.tobytes()
     return IpcHandle(
         mode="shm",
@@ -146,6 +147,7 @@ def _recv_via_shm(handle: IpcHandle) -> Any:
     import numpy as np
 
     shm = shared_memory.SharedMemory(name=handle.payload["name"])
+    assert shm.buf is not None
     dtype = _str_to_numpy_dtype(handle.dtype)
     nbytes = handle.payload["size_bytes"]
     arr = np.frombuffer(shm.buf[:nbytes], dtype=dtype).reshape(handle.shape).copy()

--- a/worldkernels/runtime/locks.py
+++ b/worldkernels/runtime/locks.py
@@ -1,0 +1,63 @@
+r"""Per-model lockfile storage under ``WORLDKERNELS_HOME/locks/``."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+from worldkernels.bootstrap import cache
+
+
+def locks_dir() -> Path:
+    p = cache.home() / "locks"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+@dataclass
+class EnvLock:
+    r"""Lockfile metadata for a per-model isolated venv."""
+
+    model_id: str
+    deps_hash: str
+    torch_abi: str
+    device: str
+    requirements: list[str] = field(default_factory=list)
+    resolved: str = ""
+
+    @property
+    def path(self) -> Path:
+        return locks_dir() / f"{_slug(self.model_id)}.lock.json"
+
+    def write(self) -> None:
+        self.path.write_text(json.dumps(asdict(self), indent=2))
+
+    @classmethod
+    def read(cls, model_id: str) -> "EnvLock | None":
+        p = locks_dir() / f"{_slug(model_id)}.lock.json"
+        if not p.exists():
+            return None
+        return cls(**json.loads(p.read_text()))
+
+
+def deps_hash(deps: list[str], torch_abi: str, device: str) -> str:
+    payload = "\n".join(sorted(deps)) + f"|{torch_abi}|{device}"
+    return hashlib.sha256(payload.encode()).hexdigest()[:16]
+
+
+def torch_abi_tag() -> str:
+    r"""Return a short tag that changes whenever torch's binary ABI changes."""
+    try:
+        import torch
+
+        cuda = getattr(torch.version, "cuda", None) or "nocuda"
+        hip = getattr(torch.version, "hip", None) or "nohip"
+        return f"{torch.__version__}-cu{cuda}-hip{hip}"
+    except ImportError:
+        return "no-torch"
+
+
+def _slug(model_id: str) -> str:
+    return model_id.replace("/", "_").replace(":", "_")

--- a/worldkernels/runtime/metrics.py
+++ b/worldkernels/runtime/metrics.py
@@ -25,6 +25,10 @@ __all__ = [
     "set_active_sessions",
     "set_vram_bytes",
     "set_cache_hit_ratio",
+    "set_isolation_tier",
+    "set_worker_processes",
+    "observe_worker_ipc_latency",
+    "inc_worker_respawns",
 ]
 
 REGISTRY = CollectorRegistry()
@@ -65,6 +69,29 @@ _CACHE_HIT_RATIO = Gauge(
     "Denoise-step cache hit ratio in [0, 1].",
     registry=REGISTRY,
 )
+_ISOLATION_TIER = Gauge(
+    "wk_model_isolation_tier",
+    "Per-model isolation tier (0 = shared env, 1 = isolated subprocess).",
+    labelnames=("model_id",),
+    registry=REGISTRY,
+)
+_WORKER_PROCESSES = Gauge(
+    "wk_worker_processes",
+    "Number of isolated worker subprocesses currently live.",
+    registry=REGISTRY,
+)
+_WORKER_IPC_LATENCY = Histogram(
+    "wk_worker_ipc_latency_seconds",
+    "Engine ↔ worker RPC round-trip latency.",
+    labelnames=("model_id",),
+    registry=REGISTRY,
+)
+_WORKER_RESPAWNS = Counter(
+    "wk_worker_respawns_total",
+    "Times an isolated worker was respawned after crashing.",
+    labelnames=("model_id",),
+    registry=REGISTRY,
+)
 
 
 def observe_step(latency_seconds: float, frames: int = 0) -> None:
@@ -90,6 +117,22 @@ def set_vram_bytes(value: float) -> None:
 
 def set_cache_hit_ratio(ratio: float) -> None:
     _CACHE_HIT_RATIO.set(ratio)
+
+
+def set_isolation_tier(model_id: str, tier: int) -> None:
+    _ISOLATION_TIER.labels(model_id=model_id).set(tier)
+
+
+def set_worker_processes(count: int) -> None:
+    _WORKER_PROCESSES.set(count)
+
+
+def observe_worker_ipc_latency(model_id: str, seconds: float) -> None:
+    _WORKER_IPC_LATENCY.labels(model_id=model_id).observe(seconds)
+
+
+def inc_worker_respawns(model_id: str) -> None:
+    _WORKER_RESPAWNS.labels(model_id=model_id).inc()
 
 
 def render() -> bytes:

--- a/worldkernels/runtime/resolver.py
+++ b/worldkernels/runtime/resolver.py
@@ -1,0 +1,134 @@
+r"""Dependency resolver: decide shared vs isolated tier (ADR-012).
+
+Wraps ``uv pip compile`` against the union of currently-loaded model constraints
+plus the incoming model's constraints. Pure function over constraints — no
+side effects on the host environment.
+"""
+
+from __future__ import annotations
+
+import logging
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from worldkernels.core.errors import WorldKernelError
+
+if TYPE_CHECKING:
+    from worldkernels.worlds.hub import ModelCard
+
+log = logging.getLogger(__name__)
+
+__all__ = [
+    "InstallPlan",
+    "SharedPlan",
+    "IsolatedPlan",
+    "IncompatibleDependenciesError",
+    "resolve_install_plan",
+]
+
+
+@dataclass(frozen=True)
+class SharedPlan:
+    r"""Resolver verdict: pack into the shared (current) env. ``deltas`` lists
+    the extra packages to install beyond what's already there."""
+
+    deltas: tuple[str, ...] = ()
+    resolved_requirements: str = ""
+
+
+@dataclass(frozen=True)
+class IsolatedPlan:
+    r"""Resolver verdict: materialize a dedicated venv for this model."""
+
+    reason: str
+    conflicting: tuple[str, ...] = field(default_factory=tuple)
+    requirements: tuple[str, ...] = field(default_factory=tuple)
+
+
+InstallPlan = SharedPlan | IsolatedPlan
+
+
+class IncompatibleDependenciesError(WorldKernelError):
+    r"""Raised when ``isolation='shared'`` is forced but the resolver returns IsolatedPlan."""
+
+
+def resolve_install_plan(
+    incoming: "ModelCard",
+    loaded: list["ModelCard"],
+) -> InstallPlan:
+    r"""Decide whether ``incoming`` can share an env with currently-loaded models.
+
+    Args:
+        incoming: ModelCard about to be loaded.
+        loaded: ModelCards currently loaded in the shared env (excludes isolated ones).
+    """
+    if incoming.isolation == "isolated":
+        return IsolatedPlan(
+            reason="card.isolation='isolated' forced",
+            requirements=tuple(_card_requirements(incoming)),
+        )
+
+    requirements = _union_requirements(loaded + [incoming])
+    if not requirements:
+        return SharedPlan(deltas=tuple(_card_requirements(incoming)))
+
+    if shutil.which("uv") is None:
+        log.warning("uv not on PATH; resolver falls back to optimistic SharedPlan")
+        return SharedPlan(deltas=tuple(_card_requirements(incoming)))
+
+    ok, output = _compile_requirements(requirements)
+    if ok:
+        return SharedPlan(deltas=tuple(_card_requirements(incoming)), resolved_requirements=output)
+
+    if incoming.isolation == "shared":
+        raise IncompatibleDependenciesError(
+            f"Cannot share env with currently-loaded models. Conflict:\n{output}"
+        )
+
+    return IsolatedPlan(
+        reason=output.strip().splitlines()[-1] if output.strip() else "unsatisfiable constraints",
+        conflicting=tuple(requirements),
+        requirements=tuple(_card_requirements(incoming)),
+    )
+
+
+def _card_requirements(card: "ModelCard") -> list[str]:
+    reqs: list[str] = list(card.constraints)
+    for comp in card.components:
+        reqs.extend(comp.deps)
+    return reqs
+
+
+def _union_requirements(cards: list["ModelCard"]) -> list[str]:
+    seen: dict[str, None] = {}
+    for card in cards:
+        for req in _card_requirements(card):
+            if req not in seen:
+                seen[req] = None
+    return list(seen)
+
+
+def _compile_requirements(requirements: list[str]) -> tuple[bool, str]:
+    r"""Run ``uv pip compile`` against ``requirements``; return ``(ok, stdout_or_stderr)``."""
+    with tempfile.NamedTemporaryFile("w", suffix=".in", delete=False) as f:
+        f.write("\n".join(requirements) + "\n")
+        in_path = Path(f.name)
+    try:
+        proc = subprocess.run(
+            ["uv", "pip", "compile", "--quiet", str(in_path)],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+        if proc.returncode == 0:
+            return True, proc.stdout
+        return False, proc.stderr or proc.stdout
+    except subprocess.TimeoutExpired:
+        return False, "uv pip compile timed out"
+    finally:
+        in_path.unlink(missing_ok=True)

--- a/worldkernels/runtime/rpc.py
+++ b/worldkernels/runtime/rpc.py
@@ -1,0 +1,193 @@
+r"""Length-prefixed msgpack RPC over a Unix domain socket.
+
+Wire format: 4-byte big-endian length header + msgpack body. Each message is
+a dict with ``id``, ``op``, ``args`` (request) or ``id``, ``ok``, ``result|error``
+(response). Synchronous request/response — the worker handles one call at a
+time per session, matching the engine's per-session step contract.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import socket
+import struct
+import tempfile
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import msgpack
+
+log = logging.getLogger(__name__)
+
+__all__ = ["RpcServer", "RpcClient", "RpcError", "default_socket_path"]
+
+_HEADER = struct.Struct(">I")
+_MAX_FRAME = 1 << 26
+
+
+class RpcError(RuntimeError):
+    r"""Raised on the client side when the worker returned an error envelope."""
+
+    def __init__(self, op: str, cls: str, message: str) -> None:
+        super().__init__(f"{op}: {cls}: {message}")
+        self.op = op
+        self.exc_cls = cls
+        self.message = message
+
+
+def default_socket_path(model_id: str) -> Path:
+    slug = model_id.replace("/", "_").replace(":", "_")
+    suffix = uuid.uuid4().hex[:8]
+    return Path(tempfile.gettempdir()) / f"wk-{slug}-{suffix}.sock"
+
+
+@dataclass
+class _Frame:
+    payload: dict[str, Any]
+
+
+def _send(sock: socket.socket, payload: dict[str, Any]) -> None:
+    body = msgpack.packb(payload, use_bin_type=True)
+    if len(body) > _MAX_FRAME:
+        raise RpcError("send", "RpcError", f"frame too large: {len(body)} bytes")
+    sock.sendall(_HEADER.pack(len(body)) + body)
+
+
+def _recv_exactly(sock: socket.socket, n: int) -> bytes:
+    chunks = []
+    remaining = n
+    while remaining:
+        chunk = sock.recv(remaining)
+        if not chunk:
+            raise ConnectionError("peer closed during recv")
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _recv(sock: socket.socket) -> dict[str, Any]:
+    header = _recv_exactly(sock, _HEADER.size)
+    (length,) = _HEADER.unpack(header)
+    if length > _MAX_FRAME:
+        raise RpcError("recv", "RpcError", f"frame too large: {length} bytes")
+    body = _recv_exactly(sock, length)
+    return msgpack.unpackb(body, raw=False)
+
+
+class RpcClient:
+    r"""Synchronous client. One in-flight call at a time; safe to reuse across calls."""
+
+    def __init__(self, socket_path: Path, connect_timeout: float = 30.0) -> None:
+        self.socket_path = Path(socket_path)
+        self._sock: socket.socket | None = None
+        self._connect_timeout = connect_timeout
+
+    def connect(self) -> None:
+        deadline = self._connect_timeout
+        import time as _time
+
+        end = _time.monotonic() + deadline
+        last_exc: Exception | None = None
+        while _time.monotonic() < end:
+            try:
+                s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                s.connect(str(self.socket_path))
+                self._sock = s
+                return
+            except (FileNotFoundError, ConnectionRefusedError) as exc:
+                last_exc = exc
+                _time.sleep(0.05)
+        raise ConnectionError(f"could not connect to {self.socket_path}: {last_exc}")
+
+    def call(self, op: str, **args: Any) -> Any:
+        if self._sock is None:
+            self.connect()
+        assert self._sock is not None
+        req = {"id": uuid.uuid4().hex, "op": op, "args": args}
+        _send(self._sock, req)
+        resp = _recv(self._sock)
+        if resp.get("ok"):
+            return resp.get("result")
+        err = resp.get("error", {})
+        raise RpcError(op, err.get("cls", "RpcError"), err.get("message", "unknown"))
+
+    def close(self) -> None:
+        if self._sock is not None:
+            try:
+                self._sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self._sock.close()
+            self._sock = None
+
+
+class RpcServer:
+    r"""Listens on a Unix socket, dispatches ops to a handler callable.
+
+    Handler signature: ``handler(op: str, args: dict) -> Any``. The server
+    handles one client at a time; if the engine reconnects, the next ``accept``
+    returns. Designed for the engine↔worker 1:1 pairing.
+    """
+
+    def __init__(self, socket_path: Path) -> None:
+        self.socket_path = Path(socket_path)
+        self._server: socket.socket | None = None
+        self._shutdown = False
+
+    def serve(self, handler) -> None:
+        if self.socket_path.exists():
+            self.socket_path.unlink()
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(self.socket_path))
+        os.chmod(self.socket_path, 0o600)
+        self._server.listen(1)
+        log.info("rpc.server listening on %s", self.socket_path)
+
+        while not self._shutdown:
+            try:
+                client, _ = self._server.accept()
+            except OSError:
+                break
+            self._serve_client(client, handler)
+
+    def _serve_client(self, client: socket.socket, handler) -> None:
+        try:
+            while not self._shutdown:
+                try:
+                    req = _recv(client)
+                except (ConnectionError, EOFError):
+                    return
+                op = req.get("op", "")
+                args = req.get("args", {})
+                req_id = req.get("id")
+                resp: dict[str, Any]
+                try:
+                    result = handler(op, args)
+                    resp = {"id": req_id, "ok": True, "result": result}
+                except Exception as exc:
+                    resp = {
+                        "id": req_id,
+                        "ok": False,
+                        "error": {"cls": type(exc).__name__, "message": str(exc)},
+                    }
+                _send(client, resp)
+                if op == "close":
+                    self._shutdown = True
+                    return
+        finally:
+            client.close()
+
+    def stop(self) -> None:
+        self._shutdown = True
+        if self._server is not None:
+            try:
+                self._server.close()
+            except OSError:
+                pass
+        try:
+            self.socket_path.unlink(missing_ok=True)
+        except OSError:
+            pass

--- a/worldkernels/runtime/worker.py
+++ b/worldkernels/runtime/worker.py
@@ -38,7 +38,6 @@ def _new_handle() -> str:
 
 
 def _handle_init(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
-
     from worldkernels.worlds.registry import get_world_class
 
     adapter = args["adapter"]

--- a/worldkernels/runtime/worker.py
+++ b/worldkernels/runtime/worker.py
@@ -38,9 +38,6 @@ def _new_handle() -> str:
 
 
 def _handle_init(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
-    import importlib
-
-    import torch
 
     from worldkernels.worlds.registry import get_world_class
 

--- a/worldkernels/runtime/worker.py
+++ b/worldkernels/runtime/worker.py
@@ -1,0 +1,230 @@
+r"""Worker subprocess entrypoint for isolated models (ADR-012 Tier 2).
+
+Invoked as ``python -m worldkernels.runtime.worker --model {id} --socket {path}
+--device {cuda:N}``. Runs inside the per-model isolated venv (`runtime/envs.py`).
+Loads the world via the standard registry, listens on a Unix socket, dispatches
+RPC ops, and shares tensors via `runtime/ipc.py` (CUDA IPC or host shm).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from worldkernels.runtime import ipc
+from worldkernels.runtime.rpc import RpcServer
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class WorkerState:
+    world: Any = None
+    device: str = "cuda"
+    dtype: Any = None
+    objects: dict[str, Any] = None
+
+    def __post_init__(self) -> None:
+        self.objects = {}
+
+
+def _new_handle() -> str:
+    return uuid.uuid4().hex
+
+
+def _handle_init(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    import importlib
+
+    import torch
+
+    from worldkernels.worlds.registry import get_world_class
+
+    adapter = args["adapter"]
+    kwargs = args.get("kwargs", {})
+    device = args.get("device", "cuda")
+    dtype_str = args.get("dtype", "torch.bfloat16")
+
+    cls = get_world_class(adapter)
+    dtype = _resolve_dtype(dtype_str)
+    world = cls(**kwargs)
+    world.initialize(device=device, dtype=dtype)
+
+    state.world = world
+    state.device = device
+    state.dtype = dtype
+    log.info("worker: loaded %s on %s (%s)", adapter, device, dtype)
+    return {"adapter": adapter, "device": device, "dtype": str(dtype)}
+
+
+def _handle_warmup(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    from worldkernels.config import WorldConfig
+
+    cfg = WorldConfig(**args.get("config", {}))
+    state.world.warmup(cfg)
+    return {"warmed": True}
+
+
+def _handle_profile_vram(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    from worldkernels.config import WorldConfig
+
+    cfg = WorldConfig(**args.get("config", {}))
+    return {"vram_mb": float(state.world.profile_vram(cfg))}
+
+
+def _handle_create_initial_state(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    from worldkernels.config import WorldConfig
+
+    cfg = WorldConfig(**args.get("config", {}))
+    seed = int(args.get("seed", 0))
+    latent_state = state.world.create_initial_state(cfg, seed)
+    h = _new_handle()
+    state.objects[h] = latent_state
+    return {"handle": h}
+
+
+def _handle_encode_action(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    from worldkernels.core.action import Action
+
+    action = Action(action_type=args["action_type"], payload=args.get("payload", {}))
+    tensor = state.world.encode_action(action)
+    h = _new_handle()
+    state.objects[h] = tensor
+    return {"handle": h}
+
+
+def _handle_transition(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    state_h = args["state_handle"]
+    action_h = args["action_handle"]
+    latent = state.objects[state_h]
+    action = state.objects[action_h]
+    new_state = state.world.transition(latent, action)
+    new_h = _new_handle()
+    state.objects[new_h] = new_state
+    return {"handle": new_h}
+
+
+def _handle_decode(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    state_h = args["state_handle"]
+    modalities = args.get("modalities", ["frames"])
+    latent = state.objects[state_h]
+    t0 = time.perf_counter()
+    obs = state.world.decode_observation(latent, modalities)
+    elapsed_ms = (time.perf_counter() - t0) * 1000.0
+    result: dict[str, Any] = {
+        "step_index": obs.step_index,
+        "generation_time_ms": getattr(obs, "generation_time_ms", elapsed_ms),
+        "decode_skipped": getattr(obs, "decode_skipped", False),
+    }
+    if obs.frames is not None:
+        result["frames"] = [_bytes_or_handle(f) for f in obs.frames]
+    if getattr(obs, "latent", None) is not None:
+        result["latent_ipc"] = _to_ipc(obs.latent)
+    return result
+
+
+def _bytes_or_handle(frame: Any) -> Any:
+    if isinstance(frame, (bytes, bytearray)):
+        return {"kind": "bytes", "data": bytes(frame)}
+    handle = ipc.share_tensor(frame)
+    return {"kind": "ipc", "handle": _ipc_to_dict(handle)}
+
+
+def _to_ipc(t: Any) -> dict[str, Any]:
+    return _ipc_to_dict(ipc.share_tensor(t))
+
+
+def _ipc_to_dict(h: ipc.IpcHandle) -> dict[str, Any]:
+    return {
+        "mode": h.mode,
+        "shape": list(h.shape),
+        "dtype": h.dtype,
+        "device": h.device,
+        "payload": h.payload,
+    }
+
+
+def _handle_release(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    h = args["handle"]
+    state.objects.pop(h, None)
+    return {"released": h}
+
+
+def _handle_health(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    import os
+
+    return {
+        "ok": True,
+        "pid": os.getpid(),
+        "device": state.device,
+        "world_loaded": state.world is not None,
+        "n_objects": len(state.objects or {}),
+    }
+
+
+def _handle_close(state: WorkerState, args: dict[str, Any]) -> dict[str, Any]:
+    state.objects.clear()
+    state.world = None
+    return {"closed": True}
+
+
+_DISPATCH = {
+    "init": _handle_init,
+    "warmup": _handle_warmup,
+    "profile_vram": _handle_profile_vram,
+    "create_initial_state": _handle_create_initial_state,
+    "encode_action": _handle_encode_action,
+    "transition": _handle_transition,
+    "decode": _handle_decode,
+    "release": _handle_release,
+    "health": _handle_health,
+    "close": _handle_close,
+}
+
+
+def _resolve_dtype(name: str) -> Any:
+    import torch
+
+    short = name.split(".")[-1]
+    return getattr(torch, short, torch.float32)
+
+
+def serve(socket_path: Path) -> None:
+    state = WorkerState()
+
+    def handler(op: str, args: dict[str, Any]) -> Any:
+        fn = _DISPATCH.get(op)
+        if fn is None:
+            raise ValueError(f"unknown op: {op}")
+        return fn(state, args)
+
+    server = RpcServer(socket_path)
+    log.info("worker: serving on %s", socket_path)
+    server.serve(handler)
+
+
+def main() -> int:
+    import argparse
+
+    p = argparse.ArgumentParser(description="worldkernels worker subprocess")
+    p.add_argument("--socket", required=True, help="Unix socket path")
+    p.add_argument("--log-level", default="INFO")
+    ns = p.parse_args()
+
+    logging.basicConfig(level=ns.log_level, format="worker[%(process)d] %(message)s")
+    try:
+        serve(Path(ns.socket))
+        return 0
+    except KeyboardInterrupt:
+        return 0
+    except Exception:
+        log.exception("worker fatal")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/worldkernels/runtime/worker.py
+++ b/worldkernels/runtime/worker.py
@@ -12,7 +12,7 @@ import logging
 import sys
 import time
 import uuid
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -27,10 +27,7 @@ class WorkerState:
     world: Any = None
     device: str = "cuda"
     dtype: Any = None
-    objects: dict[str, Any] = None
-
-    def __post_init__(self) -> None:
-        self.objects = {}
+    objects: dict[str, Any] = field(default_factory=dict)
 
 
 def _new_handle() -> str:

--- a/worldkernels/scheduler/scheduler.py
+++ b/worldkernels/scheduler/scheduler.py
@@ -85,21 +85,29 @@ class Scheduler:
         r"""Enqueue a step request for the next scheduling round."""
         self._queue.append(request)
 
-    def schedule(self) -> list[CompatibilityGroup]:
-        r"""Drain the queue into compatibility-group batches."""
+    def schedule(self, max_batch_size: int | None = None) -> list[CompatibilityGroup]:
+        r"""Drain the queue into compatibility-group batches.
+
+        Args:
+            max_batch_size: Override the configured cap. ``1`` collapses batching
+                (one request per group) — used when ``continuous_batching`` is off.
+        """
         if not self._queue:
             return []
-        groups = group_requests(self._queue, max_batch_size=self.config.max_batch_size)
+        cap = max_batch_size if max_batch_size is not None else self.config.max_batch_size
+        groups = group_requests(self._queue, max_batch_size=cap)
         self._queue.clear()
         return groups
 
-    def run_scheduled(self) -> dict[str, tuple["LatentState", "Observation"]]:
+    def run_scheduled(
+        self, max_batch_size: int | None = None
+    ) -> dict[str, tuple["LatentState", "Observation"]]:
         r"""Schedule pending requests, dispatch each group batched, and collect results.
 
         Returns a mapping from ``session_id`` to ``(new_state, observation)``.
         """
         results: dict[str, tuple[LatentState, Observation]] = {}
-        for group in self.schedule():
+        for group in self.schedule(max_batch_size=max_batch_size):
             outputs = self.worker.execute(group.requests)
             for request, output in zip(group.requests, outputs):
                 results[request.session_id] = output

--- a/worldkernels/scheduler/scheduler.py
+++ b/worldkernels/scheduler/scheduler.py
@@ -65,6 +65,7 @@ class Scheduler:
         modalities: list[str],
         step_index: int,
         decode: bool = True,
+        overrides: dict | None = None,
     ) -> tuple["LatentState", "Observation"]:
         r"""Dispatch one simulation step synchronously and return its result."""
         from worldkernels.core.request import StepRequest
@@ -77,6 +78,7 @@ class Scheduler:
             modalities=list(modalities),
             step_index=step_index,
             decode=decode,
+            overrides=overrides,
         )
         (result,) = self.worker.execute([request])
         return result

--- a/worldkernels/serving/routes.py
+++ b/worldkernels/serving/routes.py
@@ -7,10 +7,13 @@ reads touch the underlying `WorldEngine` directly.
 
 from __future__ import annotations
 
+import asyncio
 import base64
+import json
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from worldkernels.config import WorldConfig
@@ -48,6 +51,8 @@ def configure_routes(async_engine: "AsyncEngine", auth_dep: Any = None) -> APIRo
             await async_engine.load_model(
                 req.model_id,
                 alias=req.alias,
+                variant=req.variant,
+                ckpt_path=req.ckpt_path,
                 trust_remote_code=req.trust_remote_code,
                 **req.kwargs,
             )
@@ -58,6 +63,46 @@ def configure_routes(async_engine: "AsyncEngine", auth_dep: Any = None) -> APIRo
         except WorldInitError as exc:
             raise HTTPException(status_code=500, detail=str(exc))
         return {"status": "loaded", "world": req.alias or req.model_id.split("/")[-1]}
+
+    @router.post("/worlds:stream", tags=["worlds"], dependencies=deps)
+    async def load_model_stream(req: LoadModelRequest) -> StreamingResponse:
+        r"""Stream bootstrap progress as SSE events (phase, status, message, fraction)."""
+        from worldkernels.bootstrap import ProgressController
+
+        queue: asyncio.Queue = asyncio.Queue()
+        loop = asyncio.get_running_loop()
+
+        def sink(event: dict[str, Any]) -> None:
+            loop.call_soon_threadsafe(queue.put_nowait, event)
+
+        async def run_load() -> None:
+            try:
+                progress = ProgressController(mode="sink", sink=sink)
+                await asyncio.to_thread(
+                    engine.load_model,
+                    req.model_id,
+                    alias=req.alias,
+                    variant=req.variant,
+                    ckpt_path=req.ckpt_path,
+                    progress=progress,
+                    trust_remote_code=req.trust_remote_code,
+                    **req.kwargs,
+                )
+                sink({"phase": "ready", "status": "done", "message": req.alias or req.model_id})
+            except Exception as exc:
+                sink({"phase": "failed", "status": "failed", "message": str(exc)})
+            sink(None)
+
+        async def event_stream():
+            task = asyncio.create_task(run_load())
+            while True:
+                event = await queue.get()
+                if event is None:
+                    break
+                yield f"data: {json.dumps(event)}\n\n"
+            await task
+
+        return StreamingResponse(event_stream(), media_type="text/event-stream")
 
     @router.delete("/worlds/{world_id}", tags=["worlds"], dependencies=deps)
     async def unload_model(world_id: str) -> dict[str, str]:
@@ -159,6 +204,8 @@ def configure_routes(async_engine: "AsyncEngine", auth_dep: Any = None) -> APIRo
 class LoadModelRequest(BaseModel):
     model_id: str
     alias: str | None = None
+    variant: str | None = None
+    ckpt_path: str | None = None
     trust_remote_code: bool = False
     kwargs: dict[str, Any] = Field(default_factory=dict)
 

--- a/worldkernels/serving/routes.py
+++ b/worldkernels/serving/routes.py
@@ -87,7 +87,7 @@ def configure_routes(async_engine: "AsyncEngine", auth_dep: Any = None) -> APIRo
         queue: asyncio.Queue = asyncio.Queue()
         loop = asyncio.get_running_loop()
 
-        def sink(event: dict[str, Any]) -> None:
+        def sink(event: dict[str, Any] | None) -> None:
             loop.call_soon_threadsafe(queue.put_nowait, event)
 
         async def run_load() -> None:

--- a/worldkernels/serving/routes.py
+++ b/worldkernels/serving/routes.py
@@ -45,6 +45,21 @@ def configure_routes(async_engine: "AsyncEngine", auth_dep: Any = None) -> APIRo
     async def list_worlds() -> dict[str, Any]:
         return {"worlds": engine.list_worlds()}
 
+    @router.get("/config", tags=["config"], dependencies=deps)
+    async def get_config() -> dict[str, Any]:
+        from worldkernels.config.profiles import resolve_runtime_config
+        from worldkernels.config.runtime import ALL_TOGGLE_FIELDS
+
+        _, sources = resolve_runtime_config()
+        cfg = engine.config
+        return {
+            "config": {
+                f: {"value": getattr(cfg, f), "source": sources.get(f, "default")}
+                for f in ("device", "max_sessions", *ALL_TOGGLE_FIELDS)
+            },
+            "tiers": engine.list_tiers(),
+        }
+
     @router.post("/worlds", tags=["worlds"], status_code=201, dependencies=deps)
     async def load_model(req: LoadModelRequest) -> dict[str, str]:
         try:
@@ -133,7 +148,9 @@ def configure_routes(async_engine: "AsyncEngine", auth_dep: Any = None) -> APIRo
             initial_prompt=req.initial_prompt,
         )
         try:
-            sess = await async_engine.create_session(req.world, config=config, seed=req.seed)
+            sess = await async_engine.create_session(
+                req.world, config=config, seed=req.seed, overrides=req.overrides
+            )
         except WorldNotFoundError as exc:
             raise HTTPException(status_code=404, detail=str(exc))
         except SessionLimitError as exc:
@@ -220,6 +237,7 @@ class CreateSessionRequest(BaseModel):
     frames_per_step: int = 8
     initial_prompt: str | None = None
     seed: int | None = None
+    overrides: dict[str, Any] | None = None
 
 
 class StepRequest(BaseModel):

--- a/worldkernels/serving/server.py
+++ b/worldkernels/serving/server.py
@@ -14,8 +14,16 @@ from worldkernels.serving.routes import configure_routes
 def create_app(
     server_config: ServerConfig | None = None,
     device: str = "cuda",
+    runtime_config=None,
 ) -> FastAPI:
-    r"""Build the FastAPI application with engine, routes, and metrics wired up."""
+    r"""Build the FastAPI application with engine, routes, and metrics wired up.
+
+    Args:
+        server_config: HTTP-layer config (host/port/auth/CORS/max_sessions).
+        device: Compute device for the engine.
+        runtime_config: Optional `RuntimeConfig` (component toggles). ``None``
+            resolves defaults (honoring ``WK_*`` env vars).
+    """
     cfg = server_config or ServerConfig()
 
     app = FastAPI(
@@ -30,7 +38,7 @@ def create_app(
         allow_headers=["*"],
     )
 
-    engine = WorldEngine(device=device, max_sessions=cfg.max_sessions)
+    engine = WorldEngine(runtime_config, device=device, max_sessions=cfg.max_sessions)
     async_engine = AsyncEngine(engine)
     app.state.engine = engine
     app.state.async_engine = async_engine

--- a/worldkernels/utils/__init__.py
+++ b/worldkernels/utils/__init__.py
@@ -3,6 +3,6 @@ r"""Shared utilities: optional-dependency handling and device detection."""
 from __future__ import annotations
 
 from worldkernels.utils.device_info import detect_target_device
-from worldkernels.utils.import_utils import PlaceholderModule, optional_import
+from worldkernels.utils.import_utils import LazyLoader, PlaceholderModule, optional_import
 
-__all__ = ["PlaceholderModule", "optional_import", "detect_target_device"]
+__all__ = ["PlaceholderModule", "optional_import", "LazyLoader", "detect_target_device"]

--- a/worldkernels/utils/import_utils.py
+++ b/worldkernels/utils/import_utils.py
@@ -12,7 +12,7 @@ import importlib
 from types import ModuleType
 from typing import Any
 
-__all__ = ["PlaceholderModule", "optional_import"]
+__all__ = ["PlaceholderModule", "optional_import", "LazyLoader"]
 
 
 class _PlaceholderBase:
@@ -70,3 +70,41 @@ def optional_import(pkg: str, extra: str) -> ModuleType | PlaceholderModule:
         return importlib.import_module(pkg)
     except ImportError:
         return PlaceholderModule(pkg, extra)
+
+
+class LazyLoader(ModuleType):
+    r"""Defer a module's import to first attribute access.
+
+    Useful for modules with import-time side effects (e.g. op registration) that
+    we want to keep out of the cold path. On first attribute access, the real
+    module is imported and patched into ``parent_globals`` + ``sys.modules`` so
+    subsequent accesses are free.
+
+    Args:
+        local_name: Binding name in the caller's module (e.g. ``"diffusers"``).
+        parent_globals: The caller's ``globals()`` dict.
+        module_name: Fully qualified import path.
+    """
+
+    def __init__(self, local_name: str, parent_globals: dict, module_name: str) -> None:
+        super().__init__(module_name)
+        self._local_name = local_name
+        self._parent_globals = parent_globals
+        self._module_name = module_name
+
+    def _load(self) -> ModuleType:
+        import sys as _sys
+
+        module = importlib.import_module(self._module_name)
+        self._parent_globals[self._local_name] = module
+        _sys.modules[self._module_name] = module
+        self.__dict__.update(module.__dict__)
+        return module
+
+    def __getattr__(self, item: str) -> Any:
+        module = self._load()
+        return getattr(module, item)
+
+    def __dir__(self) -> list[str]:
+        module = self._load()
+        return dir(module)

--- a/worldkernels/worker/worker.py
+++ b/worldkernels/worker/worker.py
@@ -15,7 +15,7 @@ from worldkernels.worker.world_runner import WorldRunner
 if TYPE_CHECKING:
     import torch
 
-    from worldkernels.config import ParallelConfig
+    from worldkernels.config import ParallelConfig, RuntimeConfig
     from worldkernels.core.observation import Observation
     from worldkernels.core.request import StepRequest
     from worldkernels.core.session import LatentState
@@ -37,6 +37,7 @@ class Worker:
         device: str,
         dtype: "torch.dtype",
         parallel_config: "ParallelConfig | None" = None,
+        config: "RuntimeConfig | None" = None,
     ) -> None:
         from worldkernels.config import ParallelConfig
         from worldkernels.distributed import init_distributed, is_initialized
@@ -44,9 +45,10 @@ class Worker:
         self.device = device
         self.dtype = dtype
         self.parallel_config = parallel_config or ParallelConfig()
+        self.config = config
         if not is_initialized():
             init_distributed(self.parallel_config)
-        self.runner = WorldRunner(device, dtype)
+        self.runner = WorldRunner(device, dtype, config=config)
 
     def execute(
         self,

--- a/worldkernels/worker/world_runner.py
+++ b/worldkernels/worker/world_runner.py
@@ -15,6 +15,7 @@ from worldkernels.runtime.forward_context import ForwardContext, set_forward_con
 if TYPE_CHECKING:
     import torch
 
+    from worldkernels.config import RuntimeConfig
     from worldkernels.core.observation import Observation
     from worldkernels.core.request import StepRequest
     from worldkernels.core.session import LatentState
@@ -28,12 +29,19 @@ class WorldRunner:
     Args:
         device: Target device string.
         dtype: Compute dtype.
+        config: Runtime config (component toggles); used by the executor.
     """
 
-    def __init__(self, device: str, dtype: "torch.dtype") -> None:
+    def __init__(
+        self,
+        device: str,
+        dtype: "torch.dtype",
+        config: "RuntimeConfig | None" = None,
+    ) -> None:
         self.device = device
         self.dtype = dtype
-        self.executor = Executor(device=device, dtype=dtype)
+        self.config = config
+        self.executor = Executor(device=device, dtype=dtype, config=config)
 
     def run_batch(
         self,

--- a/worldkernels/worker/world_runner.py
+++ b/worldkernels/worker/world_runner.py
@@ -1,8 +1,9 @@
 r"""WorldRunner — the compute layer.
 
-Holds the executor and runs batched step requests under a
-`ForwardContext`. Equivalent to
-vLLM-Omni's ModelRunner: all model compute happens here.
+Holds the executor and runs batched step requests under a `ForwardContext`.
+Owns the runtime-feature instances (latent pool, denoise-step cache, paged KV
+cache + block allocator) gated by `RuntimeConfig`; off-flags fall through to
+the eager path with identical numerics.
 """
 
 from __future__ import annotations
@@ -19,6 +20,10 @@ if TYPE_CHECKING:
     from worldkernels.core.observation import Observation
     from worldkernels.core.request import StepRequest
     from worldkernels.core.session import LatentState
+    from worldkernels.runtime.cache.teacache import TeaCache
+    from worldkernels.runtime.memory.block_manager import BlockManager
+    from worldkernels.runtime.memory.kv_cache import KVCacheManager
+    from worldkernels.runtime.memory.latent_pool import LatentPool
 
 __all__ = ["WorldRunner"]
 
@@ -29,7 +34,7 @@ class WorldRunner:
     Args:
         device: Target device string.
         dtype: Compute dtype.
-        config: Runtime config (component toggles); used by the executor.
+        config: Runtime config (component toggles).
     """
 
     def __init__(
@@ -43,10 +48,72 @@ class WorldRunner:
         self.config = config
         self.executor = Executor(device=device, dtype=dtype, config=config)
 
+        self.pool: "LatentPool | None" = None
+        self.teacache: "TeaCache | None" = None
+        self.block_manager: "BlockManager | None" = None
+        self.kv_cache: "KVCacheManager | None" = None
+
+        if config is not None and config.latent_pool:
+            from worldkernels.runtime.memory.latent_pool import LatentPool
+
+            self.pool = LatentPool(device=device)
+
+        if config is not None and config.teacache:
+            from worldkernels.runtime.cache.teacache import TeaCache
+
+            self.teacache = TeaCache()
+
+    def ensure_kv_cache(self, frames_per_block: int = 16, num_blocks: int = 64) -> None:
+        r"""Allocate the paged KV substrate on first causal-world load.
+
+        No-op when ``kv_cache_paged`` is off or already created.
+        """
+        if self.kv_cache is not None:
+            return
+        if self.config is None or not self.config.kv_cache_paged:
+            return
+        from worldkernels.runtime.memory.block_manager import BlockManager
+        from worldkernels.runtime.memory.kv_cache import KVCacheManager
+
+        self.block_manager = BlockManager(
+            block_shape=(frames_per_block,),
+            num_blocks=num_blocks,
+            device=self.device,
+            dtype=self.dtype,
+        )
+        self.kv_cache = KVCacheManager(self.block_manager)
+
     def run_batch(
         self,
         requests: list["StepRequest"],
     ) -> list[tuple["LatentState", "Observation"]]:
-        r"""Execute a batch of step requests under a forward context."""
-        with set_forward_context(ForwardContext()):
+        r"""Execute a batch of step requests under a forward context.
+
+        Per-session overrides on the first request (the safe subset) are
+        overlaid onto the runner defaults for the duration of the batch.
+        """
+        overrides = (requests[0].overrides or {}) if requests else {}
+
+        teacache_on = overrides.get("teacache", True)
+        cache_backend = self.teacache if teacache_on else None
+
+        attn = overrides.get("attention_backend") or self._default_attention_backend()
+        attn = None if attn == "auto" else attn
+
+        iter_batch = overrides.get("iteration_batching")
+        if iter_batch is None:
+            iter_batch = bool(self.config and self.config.iteration_batching)
+
+        ctx = ForwardContext(
+            cache_backend=cache_backend,
+            pool=self.pool,
+            attention_backend=attn,
+            iteration_batching=iter_batch,
+        )
+        with set_forward_context(ctx):
             return self.executor.execute_batched(requests)
+
+    def _default_attention_backend(self) -> str | None:
+        if self.config is None:
+            return None
+        return self.config.attention_backend

--- a/worldkernels/worlds/dummy.py
+++ b/worldkernels/worlds/dummy.py
@@ -7,7 +7,7 @@ Returns random noise with no real weights or compute. Reference template for
 from __future__ import annotations
 
 import time
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterator
 
 import torch
 
@@ -38,6 +38,7 @@ class DummyWorld(InteractiveWorldModel):
     transition_mode = TransitionMode.BIDIRECTIONAL
     supports_streaming = False
     supports_kv_cache = False
+    supports_iteration_batching = True
 
     def __init__(self) -> None:
         self.device: str = "cpu"
@@ -48,6 +49,8 @@ class DummyWorld(InteractiveWorldModel):
         self.device = device
         self.dtype = dtype
         self._initialized = True
+        # tiny "weights" the runtime quantization gate can attach to
+        self._quant_target = torch.nn.Linear(8, 8).to(device=device)
 
     def warmup(self, config: WorldConfig) -> None:
         _ = self.create_initial_state(config, seed=0)
@@ -56,8 +59,44 @@ class DummyWorld(InteractiveWorldModel):
         return torch.randn(1, _LATENT_C, device=self.device, dtype=self.dtype)
 
     def transition(self, state: LatentState, action_encoded: torch.Tensor) -> LatentState:
-        noise = torch.randn_like(state.data) * 0.1
-        return LatentState(data=state.data + noise, device=state.device)
+        pool, cache = _runtime_features()
+
+        if cache is not None:
+            cache.should_compute(state.data)
+
+        if pool is not None:
+            noise = pool.acquire(state.data.shape, state.data.dtype)
+            torch.randn(*state.data.shape, out=noise)
+            noise.mul_(0.1)
+            new_data = state.data + noise
+            pool.release(noise)
+        else:
+            new_data = state.data + torch.randn_like(state.data) * 0.1
+
+        return LatentState(data=new_data, device=state.device)
+
+    def transition_iter(
+        self, state: LatentState, action_encoded: torch.Tensor
+    ) -> Iterator[LatentState]:
+        r"""Yield 3 intermediate states — the iteration-batching seam.
+
+        Uses the runtime pool + cache via the active `ForwardContext` so the
+        same toggles apply on either dispatch path.
+        """
+        pool, cache = _runtime_features()
+        cur = state.data
+        for _ in range(3):
+            if cache is not None:
+                cache.should_compute(cur)
+            if pool is not None:
+                noise = pool.acquire(cur.shape, cur.dtype)
+                torch.randn(*cur.shape, out=noise)
+                noise.mul_(0.033)
+                cur = cur + noise
+                pool.release(noise)
+            else:
+                cur = cur + torch.randn_like(cur) * 0.033
+            yield LatentState(data=cur, device=state.device)
 
     def decode_observation(self, state: LatentState, modalities: list[str]) -> Observation:
         t0 = time.perf_counter()
@@ -96,3 +135,14 @@ class DummyWorld(InteractiveWorldModel):
             self.device
         )
         return LatentState(data=data, device=self.device)
+
+
+def _runtime_features() -> tuple["object | None", "object | None"]:
+    r"""Return (pool, cache) from the active ForwardContext, or (None, None)."""
+    try:
+        from worldkernels.runtime.forward_context import get_forward_context
+
+        ctx = get_forward_context()
+    except RuntimeError:
+        return None, None
+    return getattr(ctx, "pool", None), getattr(ctx, "cache_backend", None)

--- a/worldkernels/worlds/dummy.py
+++ b/worldkernels/worlds/dummy.py
@@ -19,6 +19,8 @@ from worldkernels.worlds.base import InteractiveWorldModel
 if TYPE_CHECKING:
     from worldkernels.config import WorldConfig
     from worldkernels.core.action import Action
+    from worldkernels.runtime.cache.teacache import TeaCache
+    from worldkernels.runtime.memory.latent_pool import LatentPool
 
 _LATENT_C = 4
 _LATENT_FACTOR = 8
@@ -137,7 +139,7 @@ class DummyWorld(InteractiveWorldModel):
         return LatentState(data=data, device=self.device)
 
 
-def _runtime_features() -> tuple["object | None", "object | None"]:
+def _runtime_features() -> "tuple[LatentPool | None, TeaCache | None]":
     r"""Return (pool, cache) from the active ForwardContext, or (None, None)."""
     try:
         from worldkernels.runtime.forward_context import get_forward_context

--- a/worldkernels/worlds/hub.py
+++ b/worldkernels/worlds/hub.py
@@ -27,6 +27,23 @@ class GitPackage:
 
 
 @dataclass(frozen=True)
+class Component:
+    r"""Sub-model component with its own pip extra and import sentinel.
+
+    Args:
+        name: Component identifier (e.g. ``"wan-vae"``).
+        extra: The worldkernels extra that provides it.
+        sentinel: A module path used to detect whether the extra is installed.
+        deps: PEP 508 specs for the component's deps (used by the resolver).
+    """
+
+    name: str
+    extra: str
+    sentinel: str
+    deps: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
 class ModelCard:
     r"""Metadata for a known model.
 
@@ -57,6 +74,9 @@ class ModelCard:
     auth_required: bool = False
     allow_patterns: list[str] | None = None
     variant_pattern: list[str] | None = None
+    isolation: Literal["auto", "shared", "isolated"] = "auto"
+    constraints: list[str] = field(default_factory=list)
+    components: list[Component] = field(default_factory=list)
 
 
 _HUB: dict[str, ModelCard] = {}

--- a/worldkernels/worlds/hub.py
+++ b/worldkernels/worlds/hub.py
@@ -2,7 +2,6 @@ r"""Model hub: maps HF repo IDs and short aliases to world models and generators
 
 from __future__ import annotations
 
-import importlib as _importlib
 import logging
 from dataclasses import dataclass, field
 from typing import Any, Literal
@@ -17,19 +16,33 @@ _WAN_NEGATIVE_PROMPT = (
 
 
 @dataclass(frozen=True)
+class GitPackage:
+    r"""Spec for a github-only python package fetched on first use."""
+
+    name: str
+    url: str
+    import_check: str | None = None
+    env_path_var: str | None = None
+    ref: str | None = None
+
+
+@dataclass(frozen=True)
 class ModelCard:
     r"""Metadata for a known model.
 
     Args:
-        adapter: World-registry key of the world class. For generators this is
-            ``"generator_world"``; the engine wraps the generator pipeline.
-        kind: ``"world"`` for a true world model, ``"generator"`` for a one-shot
-            video generator surfaced via ``GeneratorWorld``.
-        generator: Pipeline-registry key of the wrapped generator (kind=generator).
-        hf_repo: HuggingFace repo ID, if any.
+        adapter: World-registry key (``"dreamdojo"``, ``"generator_world"`` …).
+        kind: ``"world"`` or ``"generator"``.
+        generator: Pipeline-registry key (for kind=generator).
+        hf_repo: HuggingFace repo ID.
         default_kwargs: Constructor kwargs merged under user kwargs.
         description: Human-readable summary.
-        pip_extra: Optional ``worldkernels`` extra to auto-install on load.
+        pip_extra: Optional worldkernels extra to auto-install.
+        git_packages: GitHub-only python deps fetched on first use.
+        variants: Named variant kwargs (``{"2b_gr1": {"variant": "2b_gr1"}}``).
+        auth_required: Whether the HF repo is gated.
+        allow_patterns: HF snapshot_download patterns.
+        variant_pattern: Per-variant HF download patterns (``{variant}`` is substituted).
     """
 
     adapter: str
@@ -39,6 +52,11 @@ class ModelCard:
     default_kwargs: dict[str, Any] = field(default_factory=dict)
     description: str = ""
     pip_extra: str | None = None
+    git_packages: list[GitPackage] = field(default_factory=list)
+    variants: dict[str, dict[str, Any]] = field(default_factory=dict)
+    auth_required: bool = False
+    allow_patterns: list[str] | None = None
+    variant_pattern: list[str] | None = None
 
 
 _HUB: dict[str, ModelCard] = {}
@@ -56,6 +74,42 @@ def list_models() -> dict[str, ModelCard]:
     return dict(_HUB)
 
 
+def infer_card_from_hf(repo_id: str) -> ModelCard | None:
+    r"""Synthesize a minimal card for an unknown ``org/repo`` reference.
+
+    Probes the HF Hub for the model card metadata; if the repo doesn't exist,
+    returns ``None``. Adapter selection is best-effort based on tags and falls
+    back to ``"generator_world"`` for diffusion-style repos.
+    """
+    try:
+        from huggingface_hub import HfApi
+        from huggingface_hub.errors import RepositoryNotFoundError
+    except ImportError:
+        return None
+
+    try:
+        info = HfApi().model_info(repo_id)
+    except RepositoryNotFoundError:
+        return None
+    except Exception as exc:
+        log.debug("HF probe failed for %s: %s", repo_id, exc)
+        return None
+
+    tags = set(info.tags or [])
+    adapter = "generator_world"
+    pip_extra = "diffusion"
+    if "diffusers" in tags:
+        adapter = "generator_world"
+        pip_extra = "diffusion"
+
+    return ModelCard(
+        adapter=adapter,
+        hf_repo=repo_id,
+        description=f"auto-inferred from {repo_id}",
+        pip_extra=pip_extra,
+    )
+
+
 _EXTRA_SENTINELS: dict[str, str] = {
     "cosmos": "transformers",
     "diffusion": "diffusers",
@@ -63,7 +117,14 @@ _EXTRA_SENTINELS: dict[str, str] = {
 
 
 def ensure_model_deps(model_id: str) -> None:
-    r"""Auto-install missing pip extras required by a model."""
+    r"""Auto-install missing pip extras for a model.
+
+    Back-compat shim retained for ``model:inspect`` and tests. New code should
+    use ``worldkernels.bootstrap.prepare``, which integrates with the unified
+    progress UI.
+    """
+    import importlib as _importlib
+
     card = _HUB.get(model_id)
     if card is None or card.pip_extra is None:
         return
@@ -75,27 +136,28 @@ def ensure_model_deps(model_id: str) -> None:
         return
     except ImportError:
         pass
-    import os
 
-    if os.environ.get("WORLDKERNELS_NO_AUTO_INSTALL"):
+    import os as _os
+
+    if _os.environ.get("WORLDKERNELS_NO_AUTO_INSTALL"):
         raise ImportError(
             f"Missing dependencies for '{model_id}'. "
             f"Install with: pip install 'worldkernels[{card.pip_extra}]'"
         )
-    import subprocess
-    import sys
+    import subprocess as _subprocess
+    import sys as _sys
 
     extra = f"worldkernels[{card.pip_extra}]"
     log.info("Auto-installing missing dependencies: pip install '%s' ...", extra)
-    subprocess.check_call([sys.executable, "-m", "pip", "install", extra])
+    _subprocess.check_call([_sys.executable, "-m", "pip", "install", extra])
     log.info("Dependencies installed successfully.")
 
 
 def resolve_model(model_id: str, **user_kwargs: Any) -> tuple[str, dict[str, Any]]:
     r"""Resolve a model identifier to ``(world_registry_key, merged_kwargs)``.
 
-    Hub default kwargs are merged under user kwargs. For a generator card the
-    wrapped generator key is injected so the engine constructs a ``GeneratorWorld``.
+    Deprecated; use ``worldkernels.bootstrap.prepare`` for new code. Retained for
+    legacy callers that don't need the bootstrap pipeline (e.g., ``model:inspect``).
     """
     card = _HUB.get(model_id)
     if card is None:
@@ -104,6 +166,14 @@ def resolve_model(model_id: str, **user_kwargs: Any) -> tuple[str, dict[str, Any
     if card.generator is not None:
         merged.setdefault("generator", card.generator)
     return card.adapter, merged
+
+
+_DREAMDOJO_GIT = GitPackage(
+    name="DreamDojo",
+    url="https://github.com/NVIDIA/DreamDojo.git",
+    import_check="cosmos_predict2",
+    env_path_var="COSMOS_PREDICT2_PATH",
+)
 
 
 def _register_builtins() -> None:
@@ -121,6 +191,21 @@ def _register_builtins() -> None:
         "14b_pretrain": "DreamDojo 14B pretrained (general)",
         "14b_gr1": "DreamDojo 14B fine-tuned on GR-1 robot",
     }
+
+    dreamdojo_card = ModelCard(
+        adapter="dreamdojo",
+        kind="world",
+        hf_repo="nvidia/DreamDojo",
+        default_kwargs={"variant": "2b_pretrain"},
+        description="DreamDojo action-conditioned video world model",
+        pip_extra="cosmos",
+        git_packages=[_DREAMDOJO_GIT],
+        variants={k: {"variant": k} for k in _dreamdojo_variants},
+    )
+    register_model("dreamdojo", dreamdojo_card)
+    register_model("nvidia/DreamDojo", dreamdojo_card)
+    register_model("DreamDojo", dreamdojo_card)
+
     for variant, desc in _dreamdojo_variants.items():
         short = f"dreamdojo-{variant.replace('_', '-')}"
         register_model(
@@ -132,21 +217,11 @@ def _register_builtins() -> None:
                 default_kwargs={"variant": variant},
                 description=desc,
                 pip_extra="cosmos",
+                git_packages=[_DREAMDOJO_GIT],
             ),
         )
 
-    _dreamdojo_card = ModelCard(
-        adapter="dreamdojo",
-        kind="world",
-        hf_repo="nvidia/DreamDojo",
-        default_kwargs={"variant": "2b_pretrain"},
-        description="DreamDojo action-conditioned video world model (default: 2B pretrain)",
-        pip_extra="cosmos",
-    )
-    register_model("dreamdojo", _dreamdojo_card)
-    register_model("nvidia/DreamDojo", _dreamdojo_card)
-
-    _cosmos_card = ModelCard(
+    cosmos_card = ModelCard(
         adapter="generator_world",
         kind="generator",
         generator="cosmos_predict2",
@@ -154,9 +229,10 @@ def _register_builtins() -> None:
         default_kwargs={"num_inference_steps": 35, "guidance_scale": 7.0},
         description="Cosmos-Predict2.5-2B text-conditioned video generator",
         pip_extra="cosmos",
+        git_packages=[_DREAMDOJO_GIT],
     )
     for name in ("cosmos-predict2", "cosmos_predict2", "nvidia/Cosmos-Predict2.5-2B"):
-        register_model(name, _cosmos_card)
+        register_model(name, cosmos_card)
 
     _wan_variants = {
         "wan2.2-ti2v-5b": (

--- a/worldkernels/worlds/remote.py
+++ b/worldkernels/worlds/remote.py
@@ -1,0 +1,241 @@
+r"""Out-of-process world proxy (ADR-012 Tier 2).
+
+``RemoteWorld`` implements the same `InteractiveWorldModel` interface as an
+in-process world but forwards every method to a subprocess via Unix-socket RPC
+and CUDA IPC (with host-shm fallback). The engine + scheduler cannot tell the
+difference; the executor doesn't distinguish.
+
+The worker process lives in a per-model isolated venv (see ``runtime/envs.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import torch
+
+from worldkernels.core.errors import WorldKernelError
+from worldkernels.core.observation import Observation
+from worldkernels.core.session import LatentState
+from worldkernels.runtime import envs, ipc
+from worldkernels.runtime.rpc import RpcClient, default_socket_path
+from worldkernels.worlds.base import InteractiveWorldModel
+
+if TYPE_CHECKING:
+    from worldkernels.config import WorldConfig
+    from worldkernels.core.action import Action
+
+log = logging.getLogger(__name__)
+
+__all__ = ["RemoteWorld", "WorkerHandle"]
+
+
+@dataclass
+class WorkerHandle:
+    process: subprocess.Popen
+    socket_path: Path
+    client: RpcClient
+
+
+class RemoteWorld(InteractiveWorldModel):
+    r"""Proxy to a `WorldModel` running in an isolated subprocess."""
+
+    name = "remote"
+
+    def __init__(
+        self,
+        model_id: str,
+        adapter: str,
+        ctor_kwargs: dict[str, Any] | None = None,
+        env_root: Path | None = None,
+        worker_module: str = "worldkernels.runtime.worker",
+        log_level: str = "INFO",
+    ) -> None:
+        self.model_id = model_id
+        self.adapter = adapter
+        self.ctor_kwargs = ctor_kwargs or {}
+        self.env_root = env_root or envs.env_path(model_id)
+        self.worker_module = worker_module
+        self.log_level = log_level
+        self.device: str = "cuda"
+        self.dtype: torch.dtype = torch.bfloat16
+        self._worker: WorkerHandle | None = None
+
+    def _spawn(self) -> WorkerHandle:
+        socket_path = default_socket_path(self.model_id)
+        py = envs.venv_python(self.model_id)
+        if not py.exists():
+            py_str = "python"
+        else:
+            py_str = str(py)
+        cmd = [py_str, "-m", self.worker_module, "--socket", str(socket_path), "--log-level", self.log_level]
+        log.info("spawning worker: %s", " ".join(cmd))
+        env = os.environ.copy()
+        env.setdefault("PYTHONUNBUFFERED", "1")
+        proc = subprocess.Popen(cmd, env=env)
+        client = RpcClient(socket_path)
+        try:
+            client.connect()
+        except ConnectionError:
+            proc.terminate()
+            raise
+        return WorkerHandle(process=proc, socket_path=socket_path, client=client)
+
+    def _ensure_worker(self) -> WorkerHandle:
+        if self._worker is None or self._worker.process.poll() is not None:
+            if self._worker is not None:
+                log.warning(
+                    "worker for %s died (exit=%s); respawning",
+                    self.model_id,
+                    self._worker.process.returncode,
+                )
+                try:
+                    from worldkernels.runtime import metrics
+
+                    metrics.inc_worker_respawns(self.model_id)
+                except Exception:
+                    pass
+            self._worker = self._spawn()
+        return self._worker
+
+    def initialize(self, device: str, dtype: torch.dtype) -> None:
+        self.device = device
+        self.dtype = dtype
+        handle = self._ensure_worker()
+        handle.client.call(
+            "init",
+            adapter=self.adapter,
+            kwargs=self.ctor_kwargs,
+            device=device,
+            dtype=str(dtype),
+        )
+
+    def warmup(self, config: "WorldConfig") -> None:
+        handle = self._ensure_worker()
+        handle.client.call("warmup", config=_config_to_dict(config))
+
+    def encode_action(self, action: "Action") -> torch.Tensor:
+        handle = self._ensure_worker()
+        res = handle.client.call(
+            "encode_action",
+            action_type=action.action_type,
+            payload=action.payload,
+        )
+        return _RemoteRef(self, res["handle"])  # type: ignore[return-value]
+
+    def transition(self, state: LatentState, action_encoded: torch.Tensor) -> LatentState:
+        handle = self._ensure_worker()
+        state_h = _ref_handle(state.data)
+        action_h = _ref_handle(action_encoded)
+        res = handle.client.call("transition", state_handle=state_h, action_handle=action_h)
+        return LatentState(data=_RemoteRef(self, res["handle"]), device=self.device)
+
+    def decode_observation(self, state: LatentState, modalities: list[str]) -> Observation:
+        handle = self._ensure_worker()
+        state_h = _ref_handle(state.data)
+        res = handle.client.call("decode", state_handle=state_h, modalities=modalities)
+        frames: list[Any] | None = None
+        raw = res.get("frames")
+        if raw is not None:
+            frames = [_unwrap_frame(f) for f in raw]
+        latent = None
+        if res.get("latent_ipc") is not None:
+            latent = ipc.recv_tensor(_dict_to_ipc(res["latent_ipc"]))
+        return Observation(
+            step_index=int(res.get("step_index", 0)),
+            generation_time_ms=float(res.get("generation_time_ms", 0.0)),
+            frames=frames,
+            latent=latent,
+        )
+
+    def create_initial_state(self, config: "WorldConfig", seed: int) -> LatentState:
+        handle = self._ensure_worker()
+        res = handle.client.call("create_initial_state", config=_config_to_dict(config), seed=int(seed))
+        return LatentState(data=_RemoteRef(self, res["handle"]), device=self.device)
+
+    def profile_vram(self, config: "WorldConfig") -> float:
+        handle = self._ensure_worker()
+        res = handle.client.call("profile_vram", config=_config_to_dict(config))
+        return float(res.get("vram_mb", 0.0))
+
+    def health(self) -> dict[str, Any]:
+        handle = self._ensure_worker()
+        return handle.client.call("health")
+
+    def close(self) -> None:
+        if self._worker is None:
+            return
+        try:
+            self._worker.client.call("close")
+        except Exception as exc:
+            log.debug("worker close errored: %s", exc)
+        finally:
+            self._worker.client.close()
+            self._terminate(self._worker.process)
+            self._worker = None
+
+    def _terminate(self, proc: subprocess.Popen, timeout: float = 5.0) -> None:
+        if proc.poll() is not None:
+            return
+        try:
+            proc.terminate()
+            proc.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            proc.send_signal(signal.SIGKILL)
+            proc.wait(timeout=2.0)
+
+
+@dataclass
+class _RemoteRef:
+    r"""Opaque server-side handle. Looks like a tensor/state to the engine."""
+
+    world: RemoteWorld
+    handle: str
+
+    def release(self) -> None:
+        try:
+            self.world._ensure_worker().client.call("release", handle=self.handle)
+        except Exception:
+            pass
+
+
+def _ref_handle(obj: Any) -> str:
+    if isinstance(obj, _RemoteRef):
+        return obj.handle
+    raise WorldKernelError(
+        f"remote world expected a server-side handle, got {type(obj).__name__}"
+    )
+
+
+def _unwrap_frame(envelope: dict[str, Any]) -> Any:
+    kind = envelope.get("kind")
+    if kind == "bytes":
+        return bytes(envelope["data"])
+    if kind == "ipc":
+        return ipc.recv_tensor(_dict_to_ipc(envelope["handle"]))
+    return envelope
+
+
+def _dict_to_ipc(d: dict[str, Any]) -> ipc.IpcHandle:
+    return ipc.IpcHandle(
+        mode=d["mode"],
+        shape=tuple(d["shape"]),
+        dtype=d["dtype"],
+        device=d["device"],
+        payload=d["payload"],
+    )
+
+
+def _config_to_dict(config: Any) -> dict[str, Any]:
+    if hasattr(config, "model_dump"):
+        return config.model_dump()
+    if hasattr(config, "__dict__"):
+        return {k: v for k, v in vars(config).items() if not k.startswith("_")}
+    return dict(config)

--- a/worldkernels/worlds/remote.py
+++ b/worldkernels/worlds/remote.py
@@ -14,7 +14,6 @@ import logging
 import os
 import signal
 import subprocess
-import time
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -75,7 +74,11 @@ class RemoteWorld(InteractiveWorldModel):
             py_str = "python"
         else:
             py_str = str(py)
-        cmd = [py_str, "-m", self.worker_module, "--socket", str(socket_path), "--log-level", self.log_level]
+        cmd = [
+            py_str, "-m", self.worker_module,
+            "--socket", str(socket_path),
+            "--log-level", self.log_level,
+        ]
         log.info("spawning worker: %s", " ".join(cmd))
         env = os.environ.copy()
         env.setdefault("PYTHONUNBUFFERED", "1")
@@ -157,7 +160,9 @@ class RemoteWorld(InteractiveWorldModel):
 
     def create_initial_state(self, config: "WorldConfig", seed: int) -> LatentState:
         handle = self._ensure_worker()
-        res = handle.client.call("create_initial_state", config=_config_to_dict(config), seed=int(seed))
+        res = handle.client.call(
+            "create_initial_state", config=_config_to_dict(config), seed=int(seed)
+        )
         return LatentState(data=_RemoteRef(self, res["handle"]), device=self.device)
 
     def profile_vram(self, config: "WorldConfig") -> float:

--- a/worldkernels/worlds/remote.py
+++ b/worldkernels/worlds/remote.py
@@ -75,9 +75,13 @@ class RemoteWorld(InteractiveWorldModel):
         else:
             py_str = str(py)
         cmd = [
-            py_str, "-m", self.worker_module,
-            "--socket", str(socket_path),
-            "--log-level", self.log_level,
+            py_str,
+            "-m",
+            self.worker_module,
+            "--socket",
+            str(socket_path),
+            "--log-level",
+            self.log_level,
         ]
         log.info("spawning worker: %s", " ".join(cmd))
         env = os.environ.copy()
@@ -214,9 +218,7 @@ class _RemoteRef:
 def _ref_handle(obj: Any) -> str:
     if isinstance(obj, _RemoteRef):
         return obj.handle
-    raise WorldKernelError(
-        f"remote world expected a server-side handle, got {type(obj).__name__}"
-    )
+    raise WorldKernelError(f"remote world expected a server-side handle, got {type(obj).__name__}")
 
 
 def _unwrap_frame(envelope: dict[str, Any]) -> Any:


### PR DESCRIPTION
flat 13-toggle runtimeconfig + profiles (baseline/fast/production)
+ env (wk_*) + cli (--profile, --set k=v) + http (get /v1/config,
session overrides).

engine consumes config (was inert); threads to worker/runner/executor.
activates: teacache, latent_pool, trajectory_cache, kv_cache_paged,
iteration_batching, offload_idle, attention_backend, quantization. live
already: torch_compile, dtype, continuous_batching, isolation.